### PR TITLE
 Fix incorrect selection rendering with custom selection colours 

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -8,7 +8,7 @@
 
 DECLARE_COMPONENT_VERSION("Album list panel",
 
-    "0.4.0-beta.4",
+    "0.4.0-beta.5",
 
     "allows you to browse through your media library\n\n"
     "based upon albumlist 3.1.0\n"

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -281,19 +281,19 @@ std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
                 return CDRF_DODEFAULT;
             return CDRF_NOTIFYITEMDRAW;
         case CDDS_ITEMPREPAINT: {
-            const auto is_focused = GetFocus() == hdr->hwndFrom;
+            const auto is_window_focused = GetFocus() == hdr->hwndFrom;
             const auto is_selected = (nmtvcd->nmcd.uItemState & CDIS_SELECTED) != 0;
-            const auto is_drop_highlighted = TreeView_GetItemState(hdr->hwndFrom, nmtvcd->nmcd.dwItemSpec, TVIS_DROPHILITED) != 0;
+            const auto is_drop_highlighted = (TreeView_GetItemState(hdr->hwndFrom, nmtvcd->nmcd.dwItemSpec, TVIS_DROPHILITED) & TVIS_DROPHILITED) != 0;
 
             cui::colours::helper colour_client(g_guid_album_list_colours);
 
             if (is_selected || is_drop_highlighted) {
                 nmtvcd->clrText =
-                    is_focused
+                    is_window_focused
                     ? colour_client.get_colour(cui::colours::colour_selection_text)
                     : colour_client.get_colour(cui::colours::colour_inactive_selection_text);
                 nmtvcd->clrTextBk =
-                    is_focused
+                    is_window_focused
                     ? colour_client.get_colour(cui::colours::colour_selection_background)
                     : colour_client.get_colour(cui::colours::colour_inactive_selection_background);
             }


### PR DESCRIPTION
The documentation for [TVM_GETITEMSTATE](https://docs.microsoft.com/en-gb/windows/desktop/Controls/tvm-getitemstate) appears to be incorrect; it sets bits other than those specified in the mask passed to it (and hence other items were being rendered as being selected).