### PR TITLE
Optimise tree view item insertion

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -193,7 +193,7 @@ void album_list_window::update_all_labels()
     if (m_root) {
         m_root->mark_all_labels_dirty();
         SendMessage(m_wnd_tv,WM_SETREDRAW, FALSE, 0);
-        TreeViewPopulator::s_setup_tree(m_wnd_tv,TVI_ROOT, m_root, 0, 0, nullptr);
+        TreeViewPopulator::s_setup_tree(m_wnd_tv,TVI_ROOT, m_root, 0, 0);
         SendMessage(m_wnd_tv,WM_SETREDRAW, TRUE, 0);
     }
 }

--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -529,7 +529,7 @@ void album_list_window::update_tree(metadb_handle_list_t<pfc::alloc_fast_aggress
             TreeView_DeleteItem(m_wnd_tv, TVI_ROOT);
         }
         else {
-            TreeViewPopulator::s_setup_tree(m_wnd_tv, TVI_ROOT, m_root, 0, 0, nullptr);
+            TreeViewPopulator::s_setup_tree(m_wnd_tv, TVI_ROOT, m_root, 0, 0);
             m_populated = true;
         }
     }

--- a/foo_uie_albumlist/tree_view_populator.cpp
+++ b/foo_uie_albumlist/tree_view_populator.cpp
@@ -1,12 +1,11 @@
 #include "stdafx.h"
 #include "tree_view_populator.h"
 
-void TreeViewPopulator::s_setup_tree(HWND wnd_tv, HTREEITEM parent, node_ptr ptr, t_size idx, t_size max_idx,
-                                     HTREEITEM ti_after)
+void TreeViewPopulator::s_setup_tree(HWND wnd_tv, HTREEITEM parent, node_ptr ptr, t_size idx, t_size max_idx)
 {
     TRACK_CALL_TEXT("album_list_panel::TreeViewPopulator::s_setup_tree");
     TreeViewPopulator populater{wnd_tv, ptr->m_level};
-    populater.setup_tree(parent, ptr, idx, max_idx, ti_after);
+    populater.setup_tree(parent, ptr, idx, max_idx, TVI_FIRST);
 }
 
 void TreeViewPopulator::s_setup_children(HWND wnd_tv, node_ptr ptr)
@@ -62,12 +61,23 @@ void TreeViewPopulator::setup_children(node_ptr ptr)
     const auto& children = ptr->get_children();
     const auto children_count = children.size();
 
-    for (size_t i{0}; i < children_count; i++) {
-        HTREEITEM ti_aft = i ? children[i - 1]->m_ti : nullptr;
-        if (ti_aft == nullptr)
-            ti_aft = TVI_FIRST;
-        setup_tree(ptr->m_ti, children[i], i, children_count, ti_aft);
+    if (ptr->m_children_inserted) {
+        for (size_t i{0}; i < children_count; ++i) {
+            HTREEITEM ti_aft = i ? children[i - 1]->m_ti : nullptr;
+
+            if (ti_aft == nullptr)
+                ti_aft = TVI_FIRST;
+
+            setup_tree(ptr->m_ti, children[i], i, children_count, ti_aft);
+        }
+    } else {
+        // If there are no existing items, use a more optimised path that inserts items in reverse
+        for (auto i{ children_count }; i > 0; --i) {
+            const auto index = i - 1;
+            setup_tree(ptr->m_ti, children[index], index, children_count, TVI_FIRST);
+        }
     }
+
     ptr->m_children_inserted = true;
 }
 

--- a/foo_uie_albumlist/tree_view_populator.h
+++ b/foo_uie_albumlist/tree_view_populator.h
@@ -9,8 +9,7 @@ public:
     void setup_children(node_ptr ptr);
 
     static void s_setup_children(HWND wnd_tv, node_ptr ptr);
-    static void s_setup_tree(HWND wnd_tv, HTREEITEM parent, node_ptr ptr, t_size idx, t_size max_idx,
-                             HTREEITEM ti_after = TVI_LAST);
+    static void s_setup_tree(HWND wnd_tv, HTREEITEM parent, node_ptr ptr, t_size idx, t_size max_idx);
 private:
     HWND m_wnd_tv;
     uint16_t m_initial_level;


### PR DESCRIPTION
As it turns out, inserting items into a tree view in reverse order is significantly faster.

This change does that, and reduces the time to insert items into the tree view by around 75%. The overall refresh time is reduced by around 35%.

(The performance problem is hinted at on https://docs.microsoft.com/en-gb/windows/win32/api/commctrl/ns-commctrl-tvinsertstructw, but it only mentions `TVI_LAST` which was not being used.)