### PR TITLE
Avoid possible crash when all items removed from library

### DIFF
--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -517,16 +517,16 @@ void album_list_window::update_tree(metadb_handle_list_t<pfc::alloc_fast_aggress
             formatter << "Album list panel: An error occured while generating the tree (" << e << ").", "Error",
             popup_message::icon_error
         );
-        m_root.reset();
+        TreeView_DeleteAllItems(m_wnd_tv);
         m_selection.reset();
-        TreeView_DeleteItem(m_wnd_tv, TVI_ROOT);
+        m_root.reset();
     }
 
     if (m_root) {
         if (!m_root->get_entries().get_count()) {
-            m_root.reset();
+            TreeView_DeleteAllItems(m_wnd_tv);
             m_selection.reset();
-            TreeView_DeleteItem(m_wnd_tv, TVI_ROOT);
+            m_root.reset();
         }
         else {
             TreeViewPopulator::s_setup_tree(m_wnd_tv, TVI_ROOT, m_root, 0, 0);

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -259,8 +259,8 @@ std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
     }
     case TVN_SELCHANGED: {
         auto param = reinterpret_cast<LPNMTREEVIEW>(hdr);
+        m_selection = param->itemNew.hItem ? reinterpret_cast<node*>(param->itemNew.lParam)->shared_from_this() : nullptr;
 
-        m_selection = reinterpret_cast<node*>(param->itemNew.lParam)->shared_from_this();
         if (param->action == TVC_BYMOUSE || param->action == TVC_BYKEYBOARD) {
             if (cfg_autosend)
                 do_autosend_playlist(m_selection, m_view);


### PR DESCRIPTION
A crash was submitted which occurred when all items were removed from the media library.

I haven't been able to reproduce it, but this attempts to address possible causes.