### PR TITLE
Stop triggering expand/collapse on custom double-click actions

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -449,7 +449,7 @@ void album_list_window::get_menu_items(ui_extension::menu_hook_t& p_hook)
     p_hook.add_node(node_settings);
 }
 
-void album_list_window::do_click_action(ClickAction click_action)
+bool album_list_window::do_click_action(ClickAction click_action)
 {
     switch (click_action) {
     case ClickAction::send_to_playlist:
@@ -464,7 +464,10 @@ void album_list_window::do_click_action(ClickAction click_action)
     case ClickAction::send_to_autosend_playlist:
         do_autosend_playlist(m_selection, m_view, true);
         break;
+    default:
+        return false;
     }
+    return true;
 }
 
 // {606E9CDD-45EE-4c3b-9FD5-49381CEBE8AE}

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -94,7 +94,7 @@ private:
     static const char* s_class_name;
     static HFONT s_font;
 
-    void do_click_action(ClickAction click_action);
+    bool do_click_action(ClickAction click_action);
 
     HWND m_wnd_tv{nullptr};
     HWND m_wnd_edit{nullptr};

--- a/foo_uie_albumlist/main_hook_proc.cpp
+++ b/foo_uie_albumlist/main_hook_proc.cpp
@@ -147,10 +147,13 @@ LRESULT WINAPI album_list_window::on_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM 
             TreeView_HitTest(wnd, &ti);
 
             if (ti.flags & TVHT_ONITEM) {
+                const auto click_processed = do_click_action(static_cast<ClickAction>(cfg_double_click_action.get_value()));
 
-                do_click_action(static_cast<ClickAction>(cfg_double_click_action.get_value()));
+                if (click_processed)
+                    return 0;
             }
         }
+        break;
     }
     return CallWindowProc(m_treeproc, wnd, msg, wp, lp);
 }


### PR DESCRIPTION
#23

This fixes a regression introduced in c7890d78893f2bc7e880066d30cc00e166e41f09 that caused the default expand/collapse double-click action to occur when a custom double-click action was set (in addition to the custom action set).