### PR TITLE
Re-add support for external metadata fields

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -8,7 +8,7 @@
 
 DECLARE_COMPONENT_VERSION("Album list panel",
 
-    "0.4.0",
+    "0.4.1",
 
     "allows you to browse through your media library\n\n"
     "based upon albumlist 3.1.0\n"

--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -400,7 +400,7 @@ void album_list_window::build_nodes(metadb_handle_list_t<pfc::alloc_fast_aggress
                 VerticalBarTitleformatTextFilter tf_hook_text_filter;
                 std::string formatted_title;
                 mmh::StringAdaptor interop_title(formatted_title);
-                script->run_hook(location, &info_ptr->info(), &tf_hook_file_info, interop_title, &tf_hook_text_filter);
+                tracks[n]->format_title(&tf_hook_file_info, interop_title, script, &tf_hook_text_filter);
                 process_byformat_add_branches(tracks[n].get_ptr(), std::move(formatted_title), entries);
             });
 


### PR DESCRIPTION
This reverts 3709a59cccd5927b96197deda941139dc1a4586a as it broke support for external metadata fields (such as those provided by the playback statistics component).

This change may increase the initialisation time of the panel with a very large library (from local testing with a large library, initialisation time is around 10% longer).