### PR TITLE
Add dark mode support and disable automatic horizontal scrolling

### DIFF
--- a/foo_uie_albumlist/albumlist.rc
+++ b/foo_uie_albumlist/albumlist.rc
@@ -101,16 +101,16 @@ EXSTYLE WS_EX_CONTROLPARENT
 FONT 8, "Tahoma", 0, 0, 0x0
 BEGIN
     GROUPBOX        "Appearance",IDC_STATIC,5,4,310,157
-    CONTROL         "Show sub-item counts",IDC_SHOW_NUMBERS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,23,89,10
+    CONTROL         "Show sub-item counts",IDC_SHOW_NUMBERS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,24,89,10
     CONTROL         "Show horizontal scroll bar",IDC_HSCROLL,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,42,103,10
     CONTROL         "Show item indices",IDC_SHOW_NUMBERS2,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,166,24,78,10
     CONTROL         "Show root node",IDC_SHOW_ROOT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,166,42,67,10
     CONTROL         "Use custom vertical item padding:",IDC_USE_ITEM_HEIGHT,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,62,123,10
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,20,61,123,10
     EDITTEXT        IDC_ITEM_HEIGHT,19,74,43,14,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_ITEM_HEIGHT_SPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | UDS_NOTHOUSANDS,64,74,9,15
     CONTROL         "Use custom indentation:",IDC_USE_INDENT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,166,60,90,12
-    EDITTEXT        IDC_INDENT,165,73,43,14,ES_AUTOHSCROLL
+    EDITTEXT        IDC_INDENT,165,74,43,14,ES_AUTOHSCROLL
     CONTROL         "Spin1",IDC_INDENT_SPIN,"msctls_updown32",UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | UDS_NOTHOUSANDS,208,67,9,15
     LTEXT           "Window frame style:",IDC_STATIC,19,99,77,8
     COMBOBOX        IDC_FRAME,19,110,76,59,CBS_DROPDOWNLIST | WS_TABSTOP
@@ -118,12 +118,12 @@ BEGIN
     CONTROL         "Autoplay on send to playlist",IDC_AUTOPLAY,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,206,105,10
     CONTROL         "Apply core sort settings to added items",IDC_ADD_ITEMS_USE_CORE_SORT,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,224,141,10
-    CONTROL         "Select added items",IDC_ADD_ITEMS_SELECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,242,76,10
+    CONTROL         "Select added items",IDC_ADD_ITEMS_SELECT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,19,243,76,10
     CONTROL         "Populate on initialisation",IDC_POPULATE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,165,206,93,10
     CONTROL         "Process keyboard shortcuts",IDC_KEYB,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,165,224,105,10
     CONTROL         "Auto-collapse on item expansion",IDC_AUTOCOLLAPSE,
                     "Button",BS_AUTOCHECKBOX | WS_TABSTOP,165,243,130,10
-    LTEXT           "Note: Performance may be reduced if both themed mode (in Columns UI Colours and Fonts configuration) and 'Show horizontal scroll bar' are enabled.",IDC_STATIC,19,132,280,17
+    LTEXT           "'Show horizontal scroll bar' may reduce performance if either themed mode or dark mode are enabled in Columns UI preferences.",IDC_STATIC,19,132,280,17
 END
 
 

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -41,6 +41,8 @@ public:
     void destroy_filter();
     void create_tree();
     void destroy_tree();
+    void update_window_theme(
+        const cui::colours::helper& colours = cui::colours::helper(g_guid_album_list_colours)) const;
     void save_scroll_position() const;
     void restore_scroll_position();
     void on_size(unsigned cx, unsigned cy);
@@ -117,4 +119,5 @@ private:
     node_ptr m_selection;
     search_filter::ptr m_filter_ptr;
     ui_selection_holder::ptr m_selection_holder;
+    std::unique_ptr<cui::colours::dark_mode_notifier> m_dark_mode_notifier;
 };

--- a/foo_uie_albumlist/main_hook_proc.cpp
+++ b/foo_uie_albumlist/main_hook_proc.cpp
@@ -18,6 +18,22 @@ static bool test_point_distance(POINT pt1, POINT pt2, int test)
 LRESULT WINAPI album_list_window::on_hook(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
+    case WM_NOTIFY: {
+        const auto hdr = reinterpret_cast<LPNMHDR>(lp);
+
+        if (hdr->code != TTN_SHOW)
+            break;
+
+        std::array<wchar_t, 128> class_name{};
+        GetClassName(hdr->hwndFrom, class_name.data(), class_name.size());
+
+        if (wcsncmp(class_name.data(), TOOLTIPS_CLASSW, class_name.size()) != 0)
+            break;
+
+        const auto is_dark = cui::colours::is_dark_mode_active();
+        SetWindowTheme(hdr->hwndFrom, is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
+        break;
+    }
     case WM_KEYDOWN:
     case WM_SYSKEYDOWN: {
         uie::window_ptr p_this{this};

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -21,6 +21,9 @@ LRESULT album_list_window::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         }
 
         static_api_ptr_t<library_manager_v3>()->register_callback(this);
+
+        m_dark_mode_notifier
+            = std::make_unique<cui::colours::dark_mode_notifier>([this, ptr = this] { update_window_theme(); });
         break;
     }
     case WM_THEMECHANGED: {
@@ -72,6 +75,7 @@ LRESULT album_list_window::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     }
     case WM_DESTROY:
+        m_dark_mode_notifier.reset();
         static_api_ptr_t<library_manager_v3>()->unregister_callback(this);
         modeless_dialog_manager::g_remove(wnd);
         destroy_tree();

--- a/foo_uie_albumlist/stdafx.h
+++ b/foo_uie_albumlist/stdafx.h
@@ -1,6 +1,6 @@
 #pragma once
 #define OEMRESOURCE
-#define _WIN32_WINNT _WIN32_WINNT_VISTA
+#define NOMINMAX
 
 #include <gsl/gsl>
 


### PR DESCRIPTION
Resolves #30 

This:

- adds support for the upcoming Columns UI dark mode
- disables automatic horizontal scrolling

Note that the tree view is always themed in dark mode.