### PR TITLE
Fix various 64-bit compiler warnings and set version to 1.0.0-beta.1

### DIFF
--- a/foo_uie_albumlist/actions.cpp
+++ b/foo_uie_albumlist/actions.cpp
@@ -4,7 +4,7 @@
 class titleformat_hook_view : public titleformat_hook {
 public:
     bool process_field(
-        titleformat_text_out* p_out, const char* p_name, unsigned p_name_length, bool& p_found_flag) override
+        titleformat_text_out* p_out, const char* p_name, size_t p_name_length, bool& p_found_flag) override
     {
         p_found_flag = false;
         if (m_view) {
@@ -17,7 +17,7 @@ public:
         return false;
     }
 
-    bool process_function(titleformat_text_out* p_out, const char* p_name, unsigned p_name_length,
+    bool process_function(titleformat_text_out* p_out, const char* p_name, size_t p_name_length,
         titleformat_hook_function_params* p_params, bool& p_found_flag) override
     {
         p_found_flag = false;

--- a/foo_uie_albumlist/foo_uie_albumlist.vcxproj
+++ b/foo_uie_albumlist/foo_uie_albumlist.vcxproj
@@ -115,7 +115,6 @@
       <RuntimeTypeInfo>false</RuntimeTypeInfo>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -151,7 +150,6 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -188,7 +186,6 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
@@ -224,7 +221,6 @@
       <PrecompiledHeader>
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <EnableEnhancedInstructionSet>NoExtensions</EnableEnhancedInstructionSet>
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>

--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -8,7 +8,7 @@
 
 DECLARE_COMPONENT_VERSION("Album list panel",
 
-    "0.4.2",
+    "1.0.0-beta.1",
 
     "allows you to browse through your media library\n\n"
     "based upon albumlist 3.1.0\n"

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -155,9 +155,9 @@ LRESULT album_list_window::on_wm_contextmenu(POINT pt)
             view_name);
     }
 
-    const unsigned IDM_MANAGER_BASE = ID_VIEW_BASE + view_names.size();
+    const int IDM_MANAGER_BASE = ID_VIEW_BASE + gsl::narrow<int>(view_names.size());
 
-    uAppendMenu(menu, MF_STRING | MF_POPUP, reinterpret_cast<UINT>(menu_view), "View");
+    uAppendMenu(menu, MF_STRING | MF_POPUP, reinterpret_cast<UINT_PTR>(menu_view), "View");
 
     if (!m_populated && !cfg_populate_on_init)
         uAppendMenu(menu, MF_STRING, ID_REFRESH, "Populate");
@@ -198,7 +198,7 @@ LRESULT album_list_window::on_wm_contextmenu(POINT pt)
     TreeView_Select(m_wnd_tv, NULL, TVGN_DROPHILITE);
 
     if (cmd > 0) {
-        if (p_menu_manager.is_valid() && static_cast<unsigned>(cmd) >= IDM_MANAGER_BASE) {
+        if (p_menu_manager.is_valid() && cmd >= IDM_MANAGER_BASE) {
             p_menu_manager->execute_by_id(cmd - IDM_MANAGER_BASE);
         } else if (cmd >= ID_VIEW_BASE) {
             const unsigned view_index = cmd - ID_VIEW_BASE;

--- a/foo_uie_albumlist/menu.h
+++ b/foo_uie_albumlist/menu.h
@@ -12,9 +12,9 @@ public:
         return true;
     }
 
-    unsigned get_children_count() const override { return m_items.get_count(); }
+    size_t get_children_count() const override { return m_items.get_count(); }
 
-    void get_child(unsigned p_index, uie::menu_node_ptr& p_out) const override { p_out = m_items[p_index].get_ptr(); }
+    void get_child(size_t p_index, uie::menu_node_ptr& p_out) const override { p_out = m_items[p_index].get_ptr(); }
 
     menu_node_select_view(album_list_window* p_wnd) : m_window{p_wnd}
     {

--- a/foo_uie_albumlist/node.cpp
+++ b/foo_uie_albumlist/node.cpp
@@ -68,7 +68,7 @@ void node::send_to_playlist(bool replace)
     }
 }
 
-node::node(const char* p_value, unsigned p_value_len, album_list_window* window, uint16_t level)
+node::node(const char* p_value, size_t p_value_len, album_list_window* window, uint16_t level)
     : m_level(level)
     , m_window(window)
 {
@@ -91,7 +91,7 @@ void node::set_data(const pfc::list_base_const_t<metadb_handle_ptr>& p_data, boo
     m_sorted = false;
 }
 
-node_ptr node::find_or_add_child(const char* p_value, unsigned p_value_len, bool b_find, bool& b_new)
+node_ptr node::find_or_add_child(const char* p_value, size_t p_value_len, bool b_find, bool& b_new)
 {
     if (!b_find)
         return add_child_v2(p_value, p_value_len);
@@ -127,7 +127,7 @@ node_ptr node::find_or_add_child(const char* p_value, unsigned p_value_len, bool
     return *m_children.insert(start, std::make_shared<node>(p_value, p_value_len, m_window, m_level + 1));
 }
 
-node_ptr node::add_child_v2(const char* p_value, unsigned p_value_len)
+node_ptr node::add_child_v2(const char* p_value, size_t p_value_len)
 {
     if (p_value_len == 0 || *p_value == 0) {
         p_value = "?";

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -9,7 +9,7 @@ public:
     bool m_children_inserted{};
     uint16_t m_level;
 
-    node(const char* p_value, unsigned p_value_len, class album_list_window* window, uint16_t level);
+    node(const char* p_value, size_t p_value_len, class album_list_window* window, uint16_t level);
 
     void sort_children();
     void sort_entries(); // for contextmenu
@@ -35,9 +35,9 @@ public:
 
     void set_data(const pfc::list_base_const_t<metadb_handle_ptr>& p_data, bool b_keep_existing);
 
-    node_ptr find_or_add_child(const char* p_value, unsigned p_value_len, bool b_find, bool& b_new);
+    node_ptr find_or_add_child(const char* p_value, size_t p_value_len, bool b_find, bool& b_new);
 
-    node_ptr add_child_v2(const char* p_value, unsigned p_value_len);
+    node_ptr add_child_v2(const char* p_value, size_t p_value_len);
 
     node_ptr add_child_v2(const char* p_value) { return add_child_v2(p_value, strlen(p_value)); }
 
@@ -56,9 +56,9 @@ public:
 
     std::vector<node_ptr>& get_children() { return m_children; }
 
-    unsigned get_num_children() const { return m_children.size(); }
+    size_t get_num_children() const { return m_children.size(); }
 
-    unsigned get_num_entries() const { return m_tracks.get_count(); }
+    size_t get_num_entries() const { return m_tracks.get_count(); }
 
 private:
     pfc::string_simple m_value;

--- a/foo_uie_albumlist/prefs.h
+++ b/foo_uie_albumlist/prefs.h
@@ -13,8 +13,8 @@ class tab_general : public preferences_tab {
 public:
     bool is_active() { return m_wnd != nullptr; }
     void refresh_views();
-    static BOOL CALLBACK g_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
-    BOOL CALLBACK on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static INT_PTR CALLBACK g_on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    INT_PTR CALLBACK on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
     HWND create(HWND wnd) override
     {
@@ -29,7 +29,7 @@ public:
 class tab_advanced : public preferences_tab {
     static bool initialised;
 
-    static BOOL CALLBACK ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static INT_PTR CALLBACK ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
 public:
     HWND create(HWND wnd) override
@@ -44,7 +44,7 @@ class config_albumlist : public preferences_page {
 
     static void make_child(HWND wnd);
 
-    static BOOL CALLBACK ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    static INT_PTR CALLBACK ConfigProc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
 public:
     HWND create(HWND parent) override

--- a/foo_uie_albumlist/tree_view_populator.cpp
+++ b/foo_uie_albumlist/tree_view_populator.cpp
@@ -88,7 +88,7 @@ const char* TreeViewPopulator::get_item_text(node_ptr ptr, t_size item_index, t_
     m_text_buffer.reset();
 
     if (cfg_show_item_indices && item_count > 0) {
-        t_size pad = 0;
+        uint32_t pad = 0;
         while (item_count > 0) {
             item_count /= 10;
             pad++;
@@ -105,7 +105,7 @@ const char* TreeViewPopulator::get_item_text(node_ptr ptr, t_size item_index, t_
         t_size num = ptr->get_num_children();
         if (num > 0) {
             char blah[64];
-            sprintf_s(blah, " (%u)", num);
+            sprintf_s(blah, " (%zu)", num);
             m_text_buffer += blah;
         }
     }


### PR DESCRIPTION
This resolves various compiler warnings that were occurring during a 64-bit build, and sets the version to 1.0.0-beta.1 in advance of a new release.

SSE2 is also now required (as it is for Columns UI).