### PR TITLE
Implement custom selection backgrounds with dark mode on

### DIFF
--- a/foo_uie_albumlist/prefs.cpp
+++ b/foo_uie_albumlist/prefs.cpp
@@ -249,9 +249,7 @@ public:
             & ~(cui::colours::colour_flag_group_foreground | cui::colours::colour_flag_group_background);
 
         if (cui::colours::is_dark_mode_active()) {
-            flags &= ~(cui::colours::colour_flag_selection_background
-                | cui::colours::colour_flag_inactive_selection_background
-                | cui::colours::colour_flag_active_item_frame);
+            flags &= ~(cui::colours::colour_flag_active_item_frame);
         }
 
         return flags;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,24 +1,24 @@
 {
   "name": "album-list-panel",
   "version-string": "git",
-  "builtin-baseline": "03ca9b59af1506a86840e3a3a01a092f3333a29b",
+  "builtin-baseline": "a7b6122f6b6504d16d96117336a0562693579933",
   "dependencies": ["fmt", "ms-gsl", "range-v3", "wil"],
   "overrides": [
     {
       "name": "fmt",
-      "version": "8.1.0"
+      "version": "9.1.0#1"
     },
     {
       "name": "ms-gsl",
-      "version-string": "3.1.0#1"
+      "version": "4.0.0"
     },
     {
       "name": "range-v3",
-      "version-date": "2021-11-02"
+      "version": "0.12.0#1"
     },
     {
       "name": "wil",
-      "version-date": "2021-12-25"
+      "version": "2023-02-02"
     }
   ]
 }


### PR DESCRIPTION
Resolves #70

This adds a workaround that gets custom selection backgrounds working with dark mode enabled. (It's not the most pleasant of workarounds, but there are few good options here.)