### PR TITLE
Fix bugs with selected item text in dark mode with custom colours

### DIFF
--- a/foo_uie_albumlist/foo_uie_albumlist.vcxproj
+++ b/foo_uie_albumlist/foo_uie_albumlist.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -29,12 +29,14 @@
     <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -204,9 +206,7 @@
       <HeaderFileName />
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
@@ -220,12 +220,9 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>Usp10.lib;comctl32.lib;shell32.lib;shlwapi.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;Msimg32.lib;uxtheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>Debug</GenerateDebugInformation>
-      <GenerateMapFile>true</GenerateMapFile>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <DataExecutionPrevention />
       <SubSystem>Windows</SubSystem>
-      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PreBuildEvent>
       <Command>py ..\scripts\pre-build.py</Command>
@@ -250,9 +247,7 @@
       </HeaderFileName>
     </Midl>
     <ClCompile>
-      <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -267,12 +262,9 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>Usp10.lib;comctl32.lib;shell32.lib;shlwapi.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;Msimg32.lib;uxtheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>Debug</GenerateDebugInformation>
-      <GenerateMapFile>true</GenerateMapFile>
       <DataExecutionPrevention>
       </DataExecutionPrevention>
       <SubSystem>Windows</SubSystem>
-      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PreBuildEvent>
       <Command>py ..\scripts\pre-build.py</Command>
@@ -313,6 +305,7 @@
     <ClInclude Include=".\tfhook.h" />
     <ClInclude Include="actions.h" />
     <ClInclude Include="menu.h" />
+    <ClInclude Include="node_formatter.h" />
     <ClInclude Include="tree_view_populator.h" />
   </ItemGroup>
   <ItemGroup>

--- a/foo_uie_albumlist/node_formatter.h
+++ b/foo_uie_albumlist/node_formatter.h
@@ -1,0 +1,32 @@
+#pragma once
+
+class NodeFormatter {
+public:
+    std::string_view format(const node_ptr& node, size_t item_index, size_t item_count)
+    {
+        m_buffer.clear();
+
+        if ((!cfg_show_item_indices || item_count == 0) && !cfg_show_subitem_counts)
+            return {node->get_val()};
+
+        if (cfg_show_item_indices && item_count > 0) {
+            uint32_t pad_digits = 0;
+
+            while (item_count > 0) {
+                item_count /= 10;
+                pad_digits++;
+            }
+            format_to(std::back_inserter(m_buffer), "{:0{}}. ", item_index + 1, pad_digits);
+        }
+
+        format_to(std::back_inserter(m_buffer), "{}", node->get_val());
+
+        if (cfg_show_subitem_counts && node->get_num_children())
+            format_to(std::back_inserter(m_buffer), " ({})", node->get_num_children());
+
+        return {m_buffer.data(), m_buffer.size()};
+    }
+
+private:
+    fmt::memory_buffer m_buffer;
+};

--- a/foo_uie_albumlist/stdafx.h
+++ b/foo_uie_albumlist/stdafx.h
@@ -3,6 +3,7 @@
 #define NOMINMAX
 
 #include <gsl/gsl>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <optional>

--- a/foo_uie_albumlist/tree_view_populator.h
+++ b/foo_uie_albumlist/tree_view_populator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "node_formatter.h"
+
 class TreeViewPopulator {
 public:
     TreeViewPopulator(HWND wnd_tv, uint16_t initial_level = 0) : m_wnd_tv{wnd_tv}, m_initial_level{initial_level} {}
@@ -14,7 +16,6 @@ private:
     HWND m_wnd_tv;
     uint16_t m_initial_level;
 
-    const char* get_item_text(node_ptr ptr, t_size item_index, t_size child_count);
-    pfc::string8_fast_aggressive m_text_buffer;
+    NodeFormatter m_node_formatter;
     pfc::stringcvt::string_wide_from_utf8_fast m_utf16_converter;
 };


### PR DESCRIPTION
This fixes some bugs related to displaying the text of selected items following https://github.com/reupen/album_list_panel/pull/127 when custom colours are used in dark mode.

In particular, it fixes problems when item indices and/or sub-item counts are enabled.

It also modernises some semi-related text formatting code, and corrects some debug build options.