### PR TITLE
Preserve expansion state and scroll position between sessions

### DIFF
--- a/foo_uie_albumlist/foo_uie_albumlist.vcxproj
+++ b/foo_uie_albumlist/foo_uie_albumlist.vcxproj
@@ -293,6 +293,7 @@
     <ClCompile Include=".\node.cpp" />
     <ClCompile Include=".\prefs.cpp" />
     <ClCompile Include=".\tfhook.cpp" />
+    <ClCompile Include="node_state.cpp" />
     <ClCompile Include="tree_view_populator.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -306,6 +307,7 @@
     <ClInclude Include="actions.h" />
     <ClInclude Include="menu.h" />
     <ClInclude Include="node_formatter.h" />
+    <ClInclude Include="node_state.h" />
     <ClInclude Include="tree_view_populator.h" />
   </ItemGroup>
   <ItemGroup>

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "node_state.h"
+
 typedef std::shared_ptr<class node> node_ptr;
 
 class node : public std::enable_shared_from_this<node> {
@@ -35,6 +37,13 @@ public:
 
     void set_data(const pfc::list_base_const_t<metadb_handle_ptr>& p_data, bool b_keep_existing);
 
+    bool is_expanded() const { return m_expanded; }
+    void set_expanded(bool expanded) { m_expanded = expanded; }
+
+    alp::SavedNodeState get_state();
+
+    std::tuple<std::vector<node_ptr>::const_iterator, std::vector<node_ptr>::const_iterator> find_child(
+        std::string_view name) const;
     node_ptr find_or_add_child(const char* p_value, size_t p_value_len, bool b_find, bool& b_new);
 
     node_ptr add_child_v2(const char* p_value, size_t p_value_len);
@@ -64,7 +73,8 @@ private:
     pfc::string_simple m_value;
     std::vector<node_ptr> m_children;
     metadb_handle_list m_tracks;
-    bool m_sorted{};
-    bool m_bydir{};
+    bool m_sorted : 1 {};
+    bool m_bydir : 1 {};
+    bool m_expanded : 1 {};
     class album_list_window* m_window{};
 };

--- a/foo_uie_albumlist/node_state.cpp
+++ b/foo_uie_albumlist/node_state.cpp
@@ -1,0 +1,65 @@
+#include "stdafx.h"
+
+namespace alp {
+
+auto find_node_state(const std::vector<SavedNodeState>& items, const char* child_name) -> std::optional<SavedNodeState>
+{
+    const pfc::stringcvt::string_wide_from_utf8 wide_child_name(child_name);
+
+    const auto [start, end] = std::ranges::equal_range(
+        items, wide_child_name, [](auto&& left, auto&& right) { return StrCmpLogicalW(left, right) < 0; },
+        [](auto& child) { return pfc::stringcvt::string_wide_from_utf8(child.name); });
+
+    if (start != end)
+        return *start;
+
+    return {};
+}
+
+void write_node_state(stream_writer* writer, const SavedNodeState& state, abort_callback& aborter)
+{
+    stream_writer_memblock temp_writer;
+    temp_writer.write_string(state.name, aborter);
+    temp_writer.write_lendian_t(state.expanded, aborter);
+
+    temp_writer.write_lendian_t(gsl::narrow<uint32_t>(state.children.size()), aborter);
+
+    for (const auto& child : state.children) {
+        stream_writer_memblock child_writer;
+
+        write_node_state(&child_writer, child, aborter);
+
+        temp_writer.write(child_writer.m_data.get_ptr(), child_writer.m_data.get_size(), aborter);
+    }
+
+    writer->write_lendian_t(gsl::narrow<uint32_t>(temp_writer.m_data.get_size()), aborter);
+    writer->write(temp_writer.m_data.get_ptr(), temp_writer.m_data.get_size(), aborter);
+}
+
+auto read_node_state(stream_reader* reader, abort_callback& aborter) -> SavedNodeState
+{
+    const auto size = reader->read_lendian_t<uint32_t>(aborter);
+
+    fbh::StreamReaderLimiter limited_reader(reader, size);
+
+    SavedNodeState state;
+    state.name = limited_reader.read_string(aborter);
+    state.expanded = limited_reader.read_lendian_t<bool>(aborter);
+    auto child_count = limited_reader.read_lendian_t<uint32_t>(aborter);
+
+    state.children = std::ranges::views::iota(0u, child_count)
+        | std::ranges::views::transform(
+            [&limited_reader, &aborter](auto) { return read_node_state(&limited_reader, aborter); })
+        | ranges::to_vector;
+
+    // Behaviour of StrCmpLogicalW can change e.g. with Windows updates, so re-sort after deserialising
+    std::ranges::sort(
+        state.children, [](auto&& left, auto&& right) { return StrCmpLogicalW(left, right) < 0; },
+        [](auto& item) { return pfc::stringcvt::string_wide_from_utf8(item.name); });
+
+    limited_reader.flush_remaining(aborter);
+
+    return state;
+}
+
+} // namespace alp

--- a/foo_uie_albumlist/node_state.h
+++ b/foo_uie_albumlist/node_state.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace alp {
+
+struct SavedNodeState {
+    pfc::string name;
+    bool expanded{};
+    std::vector<SavedNodeState> children;
+};
+
+auto find_node_state(const std::vector<SavedNodeState>& items, const char* child_name) -> std::optional<SavedNodeState>;
+void write_node_state(stream_writer* writer, const SavedNodeState& state, abort_callback& aborter);
+auto read_node_state(stream_reader* reader, abort_callback& aborter) -> SavedNodeState;
+
+} // namespace alp

--- a/foo_uie_albumlist/stdafx.h
+++ b/foo_uie_albumlist/stdafx.h
@@ -7,6 +7,8 @@
 
 #include <algorithm>
 #include <optional>
+#include <ranges>
+#include <string_view>
 
 #include <ppl.h>
 #include <concurrent_vector.h>
@@ -26,3 +28,5 @@
 #include "main.h"
 #include "tfhook.h"
 #include "prefs.h"
+
+using namespace std::literals;

--- a/foo_uie_albumlist/tree_view_populator.h
+++ b/foo_uie_albumlist/tree_view_populator.h
@@ -6,13 +6,15 @@ class TreeViewPopulator {
 public:
     TreeViewPopulator(HWND wnd_tv, uint16_t initial_level = 0) : m_wnd_tv{wnd_tv}, m_initial_level{initial_level} {}
 
-    void setup_tree(HTREEITEM parent, node_ptr ptr, t_size idx, t_size max_idx, HTREEITEM ti_after);
-    void setup_children(node_ptr ptr);
-
     static void s_setup_children(HWND wnd_tv, node_ptr ptr);
-    static void s_setup_tree(HWND wnd_tv, HTREEITEM parent, node_ptr ptr, t_size idx, t_size max_idx);
+    static void s_setup_tree(HWND wnd_tv, HTREEITEM parent, node_ptr ptr, std::optional<alp::SavedNodeState> node_state,
+        t_size idx, t_size max_idx);
 
 private:
+    void setup_tree(HTREEITEM parent, node_ptr ptr, std::optional<alp::SavedNodeState> node_state, t_size idx,
+        t_size max_idx, HTREEITEM ti_after);
+    void setup_children(node_ptr ptr, std::optional<alp::SavedNodeState> node_state);
+
     HWND m_wnd_tv;
     uint16_t m_initial_level;
 


### PR DESCRIPTION
#140
Resolves #35

This adds preservation of item expansion state and the tree view scroll positions between sessions.

On foobar2000 2.0 and newer, the tree view is also now disabled until the media library has finished initialising (otherwise restoring the scroll position is problematic).