### PR TITLE
Track initialisation time on foobar2000 2.0 and newer

### DIFF
--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -139,6 +139,7 @@ private:
     search_filter::ptr m_filter_ptr;
     ui_selection_holder::ptr m_selection_holder;
 
+    double m_initialisation_time{};
     library_manager_v4::ptr m_library_v4;
     library_manager_v3::ptr m_library_v3;
 };

--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -474,10 +474,14 @@ void album_list_window::remove_nodes(metadb_handle_list_t<pfc::alloc_fast_aggres
 
 void album_list_window::on_items_added(const pfc::list_base_const_t<metadb_handle_ptr>& p_const_data)
 {
+    const auto timer = pfc::hires_timer::create_and_start();
+
     metadb_handle_list_t<pfc::alloc_fast_aggressive> to_add = p_const_data;
     metadb_handle_list_t<pfc::alloc_fast_aggressive> to_remove;
 
     update_tree(to_add, to_remove, true);
+
+    m_initialisation_time += timer.query();
 }
 
 void album_list_window::on_items_removed(const pfc::list_base_const_t<metadb_handle_ptr>& p_data_const)
@@ -502,10 +506,15 @@ void album_list_window::on_items_modified_v2(metadb_handle_list_cref items, meta
 
 void album_list_window::on_library_initialized()
 {
+    const auto timer = pfc::hires_timer::create_and_start();
+
     m_node_state.reset();
     if (m_wnd_tv && m_populated) {
         enable_tree_view();
         restore_scroll_position();
+
+        m_initialisation_time += timer.query();
+        console::print("Album list panel: initialised in ", pfc::format_float(m_initialisation_time, 0, 3), " s");
     }
 }
 
@@ -582,6 +591,6 @@ void album_list_window::refresh_tree()
 
     update_tree(to_add, to_remove, false);
 
-    console::formatter formatter;
-    formatter << "Album list panel: initialised in " << pfc::format_float(timer.query(), 0, 3) << " s";
+    if (!m_library_v4.is_valid() || m_library_v4->is_initialized())
+        console::print("Album list panel: initialised in ", pfc::format_float(timer.query(), 0, 3), " s");
 }


### PR DESCRIPTION
Resolves #139

This fixes tracking and reporting of the initialisation time on foobar2000 2.0 and newer, where the media library initialises in the background, and in phases.

(Initialisation of the panel in at start-up on foobar2000 2.0 is also much slower than a full refresh; there may be some scope to optimise this, or just delay initialisation until the media library has initialised.)