### PR TITLE
Improve performance

### DIFF
--- a/foo_uie_albumlist/foo_uie_albumlist.vcxproj
+++ b/foo_uie_albumlist/foo_uie_albumlist.vcxproj
@@ -120,6 +120,7 @@
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -167,6 +168,7 @@
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -213,6 +215,7 @@
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -255,6 +258,7 @@
       <AdditionalOptions>/permissive- /source-charset:utf-8 %(AdditionalOptions)</AdditionalOptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -132,9 +132,7 @@ void album_list_window::s_update_all_showhscroll()
         const auto wnd = s_instances[i]->m_wnd_tv;
         if (wnd) {
             uih::DisableRedrawScope disable_redrawing(s_instances[i]->get_wnd());
-            s_instances[i]->destroy_tree();
-            s_instances[i]->create_tree();
-            s_instances[i]->on_size();
+            s_instances[i]->recreate_tree(true);
         }
     }
 }
@@ -201,8 +199,7 @@ void album_list_window::on_view_script_change(const char* p_view_before, const c
 {
     if (get_wnd()) {
         if (!stricmp_utf8(p_view_before, m_view)) {
-            m_view = p_view;
-            refresh_tree();
+            set_view(p_view);
         }
     }
 }
@@ -409,13 +406,33 @@ void album_list_window::create_tree()
     }
 }
 
-void album_list_window::destroy_tree()
+void album_list_window::destroy_tree(bool should_save_scroll_position)
 {
     if (m_wnd_tv) {
-        save_scroll_position();
+        if (should_save_scroll_position)
+            save_scroll_position();
+
         DestroyWindow(m_wnd_tv);
         m_wnd_tv = nullptr;
     }
+}
+
+void album_list_window::recreate_tree(bool save_state)
+{
+    if (!m_wnd_tv)
+        return;
+
+    if (m_root && save_state)
+        m_node_state = m_root->get_state(m_selection);
+
+    SetWindowRedraw(get_wnd(), FALSE);
+
+    destroy_tree(save_state);
+    create_tree();
+    on_size();
+
+    SetWindowRedraw(get_wnd(), TRUE);
+    RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_ALLCHILDREN);
 }
 
 void album_list_window::save_scroll_position() const
@@ -537,7 +554,7 @@ const char* album_list_window::get_view() const
 void album_list_window::set_view(const char* view)
 {
     m_view = view;
-    refresh_tree();
+    recreate_tree(false);
 }
 
 void album_list_window::get_menu_items(ui_extension::menu_hook_t& p_hook)

--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -379,11 +379,6 @@ void album_list_window::create_tree()
     if (!cfg_show_horizontal_scroll_bar)
         styles |= TVS_NOHSCROLL;
 
-    m_enabled = !m_library_v4.is_valid() || m_library_v4->is_initialized();
-
-    if (!m_enabled)
-        styles |= WS_DISABLED;
-
     m_wnd_tv = CreateWindowEx(ex_styles, WC_TREEVIEW, L"Album list", styles, 0, 0, 0, 0, wnd,
         reinterpret_cast<HMENU>(IDC_TREE), core_api::get_my_instance(), nullptr);
 
@@ -479,14 +474,6 @@ void album_list_window::restore_scroll_position()
     if (is_initialised) {
         m_saved_scroll_position.reset();
     }
-}
-
-void album_list_window::enable_tree_view()
-{
-    if (!m_enabled)
-        EnableWindow(m_wnd_tv, TRUE);
-
-    m_enabled = true;
 }
 
 void album_list_window::get_config(stream_writer* p_writer, abort_callback& p_abort) const

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -59,7 +59,9 @@ public:
     void create_filter();
     void destroy_filter();
     void create_tree();
-    void destroy_tree();
+    void destroy_tree(bool should_save_scroll_position);
+    void recreate_tree(bool save_state);
+
     void save_scroll_position() const;
     void restore_scroll_position();
     void on_size(unsigned cx, unsigned cy);

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "node_formatter.h"
+
 #define IDC_TREE 1000
 #define IDC_FILTER 1001
 #define EDIT_TIMER_ID 2001
@@ -138,7 +140,7 @@ private:
     std::optional<alp::SavedNodeState> m_node_state;
     search_filter::ptr m_filter_ptr;
     ui_selection_holder::ptr m_selection_holder;
-
+    NodeFormatter m_node_formatter;
     double m_initialisation_time{};
     library_manager_v4::ptr m_library_v4;
     library_manager_v3::ptr m_library_v3;

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -110,8 +110,6 @@ private:
 
     LRESULT WINAPI on_tree_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
-    void enable_tree_view();
-
     static inline pfc::ptr_list_t<album_list_window> s_instances;
     static const GUID s_extension_guid;
     static const char* s_class_name;
@@ -126,7 +124,6 @@ private:
     WNDPROC m_treeproc{nullptr};
     bool m_initialised{false};
     bool m_populated{false};
-    bool m_enabled{};
     bool m_dragging{false};
     bool m_clicked{false};
     bool m_filter{false};
@@ -141,7 +138,6 @@ private:
     search_filter::ptr m_filter_ptr;
     ui_selection_holder::ptr m_selection_holder;
     NodeFormatter m_node_formatter;
-    double m_initialisation_time{};
     library_manager_v4::ptr m_library_v4;
     library_manager_v3::ptr m_library_v3;
 };

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -266,6 +266,13 @@ LRESULT album_list_window::on_wm_contextmenu(POINT pt)
 std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
 {
     switch (hdr->code) {
+    case TVN_GETDISPINFO: {
+        auto param = reinterpret_cast<LPNMTVDISPINFO>(hdr);
+        node_ptr p_node = reinterpret_cast<node*>(param->item.lParam)->shared_from_this();
+        auto text = m_node_formatter.format(p_node);
+        wcscpy_s(param->item.pszText, param->item.cchTextMax, text);
+        break;
+    }
     case TVN_ITEMEXPANDING: {
         auto param = reinterpret_cast<LPNMTREEVIEW>(hdr);
         node_ptr p_node = reinterpret_cast<node*>(param->itemNew.lParam)->shared_from_this();

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -100,7 +100,7 @@ LRESULT album_list_window::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         if (m_root) {
             m_node_state = m_root->get_state(m_selection);
         }
-        destroy_tree();
+        destroy_tree(true);
         destroy_filter();
         m_selection_holder.release();
         m_root.reset();
@@ -227,8 +227,7 @@ LRESULT album_list_window::on_wm_contextmenu(POINT pt)
         } else if (cmd >= ID_VIEW_BASE) {
             const unsigned view_index = cmd - ID_VIEW_BASE;
             if (view_index < view_names.size()) {
-                m_view = view_names[view_index].c_str();
-                refresh_tree();
+                set_view(view_names[view_index].c_str());
             }
         } else if (cmd < ID_VIEW_BASE) {
             switch (cmd) {

--- a/foo_uie_albumlist/node.cpp
+++ b/foo_uie_albumlist/node.cpp
@@ -65,8 +65,9 @@ void node::send_to_playlist(bool replace)
     }
 }
 
-node::node(const char* name, size_t name_length, album_list_window* window, uint16_t level)
+node::node(const char* name, size_t name_length, album_list_window* window, uint16_t level, std::weak_ptr<node> parent)
     : m_level(level)
+    , m_parent(std::move(parent))
     , m_window(window)
 {
     if (name && name_length > 0) {
@@ -129,7 +130,8 @@ node_ptr node::find_or_add_child(const char* p_value, size_t p_value_len, bool b
 
     b_new = true;
 
-    return *m_children.insert(start, std::make_shared<node>(p_value, p_value_len, m_window, m_level + 1));
+    return *m_children.insert(
+        start, std::make_shared<node>(p_value, p_value_len, m_window, m_level + 1, this->shared_from_this()));
 }
 
 node_ptr node::add_child_v2(const char* p_value, size_t p_value_len)
@@ -138,7 +140,7 @@ node_ptr node::add_child_v2(const char* p_value, size_t p_value_len)
         p_value = "?";
         p_value_len = 1;
     }
-    node_ptr temp = std::make_shared<node>(p_value, p_value_len, m_window, m_level + 1);
+    node_ptr temp = std::make_shared<node>(p_value, p_value_len, m_window, m_level + 1, this->shared_from_this());
     m_children.emplace_back(temp);
     return temp;
 }

--- a/foo_uie_albumlist/node.cpp
+++ b/foo_uie_albumlist/node.cpp
@@ -4,11 +4,11 @@ void node::sort_children()
 {
     const auto count = m_children.size();
     mmh::Permutation permutation(count);
-    pfc::array_staticsize_t<pfc::stringcvt::string_wide_from_utf8_fast> sortdata(count);
 
-    for (size_t n = 0; n < count; n++)
-        sortdata[n].convert(m_children[n]->m_value);
-    mmh::sort_get_permutation(sortdata, permutation, StrCmpLogicalW, false, false, true);
+    mmh::sort_get_permutation(
+        m_children, permutation,
+        [](auto& left, auto& right) { return StrCmpLogicalW(left->get_name_utf16(), right->get_name_utf16()); }, false,
+        false, true);
 
     mmh::destructive_reorder(m_children, permutation);
     concurrency::parallel_for(size_t{0}, count, [this](size_t n) { m_children[n]->sort_children(); });
@@ -34,10 +34,7 @@ void node::sort_entries() // for contextmenu
 void node::create_new_playlist()
 {
     static_api_ptr_t<playlist_manager> api;
-    pfc::string8 name = m_value.get_ptr();
-    if (name.is_empty())
-        name = "All music";
-    const size_t index = api->create_playlist(name, pfc_infinite, pfc_infinite);
+    const size_t index = api->create_playlist(get_name(), pfc_infinite, pfc_infinite);
     if (index != pfc_infinite) {
         api->set_active_playlist(index);
         send_to_playlist(true);
@@ -68,12 +65,12 @@ void node::send_to_playlist(bool replace)
     }
 }
 
-node::node(const char* p_value, size_t p_value_len, album_list_window* window, uint16_t level)
+node::node(const char* name, size_t name_length, album_list_window* window, uint16_t level)
     : m_level(level)
     , m_window(window)
 {
-    if (p_value && p_value_len > 0) {
-        m_value.set_string(p_value, p_value_len);
+    if (name && name_length > 0) {
+        m_name.set_string(name, name_length);
     }
     m_sorted = false;
 }
@@ -94,7 +91,7 @@ void node::set_data(const pfc::list_base_const_t<metadb_handle_ptr>& p_data, boo
 alp::SavedNodeState node::get_state(const node_ptr& selection)
 {
     alp::SavedNodeState state;
-    state.name = m_value;
+    state.name = m_name;
     state.expanded = m_expanded;
     state.selected = selection.get() == this;
 
@@ -115,7 +112,7 @@ std::tuple<std::vector<node_ptr>::const_iterator, std::vector<node_ptr>::const_i
     return std::ranges::equal_range(
         m_children, value_utf16.get_ptr(),
         [](const wchar_t* left, const wchar_t* right) { return StrCmpLogicalW(left, right) < 0; },
-        [](auto& node) { return pfc::stringcvt::string_wide_from_utf8(node->m_value); });
+        [](auto& node) { return node->get_name_utf16(); });
 }
 
 node_ptr node::find_or_add_child(const char* p_value, size_t p_value_len, bool b_find, bool& b_new)

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "config.h"
 #include "node_state.h"
 
 typedef std::shared_ptr<class node> node_ptr;
@@ -11,7 +12,8 @@ public:
     bool m_children_inserted{};
     uint16_t m_level;
 
-    node(const char* name, size_t name_length, class album_list_window* window, uint16_t level);
+    node(const char* name, size_t name_length, class album_list_window* window, uint16_t level,
+        std::weak_ptr<node> parent = {});
 
     void sort_children();
     void sort_entries(); // for contextmenu
@@ -79,7 +81,15 @@ public:
 
     size_t get_num_entries() const { return m_tracks.get_count(); }
 
+    std::weak_ptr<node>& get_parent() { return m_parent; }
+
+    void set_display_index(std::optional<size_t> display_index) { m_display_index = display_index; }
+
+    std::optional<size_t> get_display_index() const { return m_display_index; }
+
 private:
+    std::weak_ptr<node> m_parent;
+    std::optional<size_t> m_display_index;
     pfc::string_simple m_name;
     pfc::stringcvt::string_wide_from_utf8 m_name_utf16;
     std::vector<node_ptr> m_children;

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -11,7 +11,7 @@ public:
     bool m_children_inserted{};
     uint16_t m_level;
 
-    node(const char* p_value, size_t p_value_len, class album_list_window* window, uint16_t level);
+    node(const char* name, size_t name_length, class album_list_window* window, uint16_t level);
 
     void sort_children();
     void sort_entries(); // for contextmenu
@@ -29,7 +29,17 @@ public:
         m_children.clear();
     }
 
-    const char* get_val() { return m_value.is_empty() ? "All music" : m_value.get_ptr(); }
+    const char* get_name() const { return m_name.is_empty() ? "All music" : m_name.get_ptr(); }
+    const wchar_t* get_name_utf16()
+    {
+        if (m_name.is_empty())
+            return L"All music";
+
+        if (m_name_utf16.is_empty())
+            m_name_utf16.convert(m_name.get_ptr(), m_name.get_length());
+
+        return m_name_utf16.get_ptr();
+    }
 
     void add_entry(const metadb_handle_ptr& p_entry) { m_tracks.add_item(p_entry); }
 
@@ -70,7 +80,8 @@ public:
     size_t get_num_entries() const { return m_tracks.get_count(); }
 
 private:
-    pfc::string_simple m_value;
+    pfc::string_simple m_name;
+    pfc::stringcvt::string_wide_from_utf8 m_name_utf16;
     std::vector<node_ptr> m_children;
     metadb_handle_list m_tracks;
     bool m_sorted : 1 {};

--- a/foo_uie_albumlist/node_formatter.h
+++ b/foo_uie_albumlist/node_formatter.h
@@ -2,21 +2,27 @@
 
 class NodeFormatter {
 public:
-    const wchar_t* format(const node_ptr& node, size_t item_index, size_t item_count)
+    const wchar_t* format(const node_ptr& node)
     {
         m_buffer.clear();
 
-        if ((!cfg_show_item_indices || item_count == 0) && !cfg_show_subitem_counts)
-            return {node->get_name_utf16()};
+        const auto parent = node->get_parent().lock();
+        auto item_count = parent ? parent->get_num_children() : 0;
 
-        if (cfg_show_item_indices && item_count > 0) {
+        const auto item_index = node->get_display_index();
+
+        if ((!cfg_show_item_indices || item_count == 0) && !cfg_show_subitem_counts)
+            return node->get_name_utf16();
+
+        if (cfg_show_item_indices && item_index && parent) {
             uint32_t pad_digits = 0;
 
             while (item_count > 0) {
                 item_count /= 10;
                 pad_digits++;
             }
-            format_to(std::back_inserter(m_buffer), L"{:0{}}. ", item_index + 1, pad_digits);
+
+            format_to(std::back_inserter(m_buffer), L"{:0{}}. ", *item_index + 1, pad_digits);
         }
 
         format_to(std::back_inserter(m_buffer), L"{}", node->get_name_utf16());

--- a/foo_uie_albumlist/node_formatter.h
+++ b/foo_uie_albumlist/node_formatter.h
@@ -2,12 +2,12 @@
 
 class NodeFormatter {
 public:
-    std::string_view format(const node_ptr& node, size_t item_index, size_t item_count)
+    const wchar_t* format(const node_ptr& node, size_t item_index, size_t item_count)
     {
         m_buffer.clear();
 
         if ((!cfg_show_item_indices || item_count == 0) && !cfg_show_subitem_counts)
-            return {node->get_val()};
+            return {node->get_name_utf16()};
 
         if (cfg_show_item_indices && item_count > 0) {
             uint32_t pad_digits = 0;
@@ -16,17 +16,19 @@ public:
                 item_count /= 10;
                 pad_digits++;
             }
-            format_to(std::back_inserter(m_buffer), "{:0{}}. ", item_index + 1, pad_digits);
+            format_to(std::back_inserter(m_buffer), L"{:0{}}. ", item_index + 1, pad_digits);
         }
 
-        format_to(std::back_inserter(m_buffer), "{}", node->get_val());
+        format_to(std::back_inserter(m_buffer), L"{}", node->get_name_utf16());
 
         if (cfg_show_subitem_counts && node->get_num_children())
-            format_to(std::back_inserter(m_buffer), " ({})", node->get_num_children());
+            format_to(std::back_inserter(m_buffer), L" ({})", node->get_num_children());
 
-        return {m_buffer.data(), m_buffer.size()};
+        m_buffer.push_back(0);
+
+        return m_buffer.data();
     }
 
 private:
-    fmt::memory_buffer m_buffer;
+    fmt::basic_memory_buffer<wchar_t> m_buffer;
 };

--- a/foo_uie_albumlist/stdafx.h
+++ b/foo_uie_albumlist/stdafx.h
@@ -4,6 +4,7 @@
 
 #include <gsl/gsl>
 #include <fmt/format.h>
+#include <fmt/xchar.h>
 
 #include <algorithm>
 #include <optional>

--- a/foo_uie_albumlist/tree_view_populator.cpp
+++ b/foo_uie_albumlist/tree_view_populator.cpp
@@ -29,19 +29,18 @@ void TreeViewPopulator::setup_tree(HTREEITEM parent, node_ptr ptr, std::optional
     if ((!ptr->m_ti || ptr->m_label_dirty) && (ptr->m_level > 0 || cfg_show_root_node)) {
         auto text = m_node_formatter.format(ptr, idx, max_idx);
 
-        m_utf16_converter.convert(text.data(), text.size());
         if (ptr->m_ti) {
-            TVITEM tvi{};
+            TVITEMEX tvi{};
             tvi.hItem = ptr->m_ti;
             tvi.mask = TVIF_TEXT;
-            tvi.pszText = const_cast<WCHAR*>(m_utf16_converter.get_ptr());
+            tvi.pszText = const_cast<WCHAR*>(text);
             TreeView_SetItem(m_wnd_tv, &tvi);
         } else {
             TVINSERTSTRUCT is{};
             is.hParent = parent;
             is.hInsertAfter = ti_after;
             is.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_STATE;
-            is.item.pszText = const_cast<WCHAR*>(m_utf16_converter.get_ptr());
+            is.item.pszText = const_cast<WCHAR*>(text);
             is.item.lParam = reinterpret_cast<LPARAM>(ptr.get());
             is.item.state = expanded ? TVIS_EXPANDED : 0;
             is.item.stateMask = TVIS_EXPANDED;
@@ -83,7 +82,7 @@ void TreeViewPopulator::setup_children(node_ptr ptr, std::optional<alp::SavedNod
             auto& child = children[i];
 
             std::optional<alp::SavedNodeState> child_state
-                = node_state ? find_node_state(node_state->children, child->get_val()) : std::nullopt;
+                = node_state ? find_node_state(node_state->children, child->get_name()) : std::nullopt;
 
             setup_tree(ptr->m_ti, child, std::move(child_state), i, children_count, ti_aft);
         }
@@ -94,7 +93,7 @@ void TreeViewPopulator::setup_children(node_ptr ptr, std::optional<alp::SavedNod
             auto& child = children[index];
 
             std::optional<alp::SavedNodeState> child_state
-                = node_state ? find_node_state(node_state->children, child->get_val()) : std::nullopt;
+                = node_state ? find_node_state(node_state->children, child->get_name()) : std::nullopt;
 
             setup_tree(ptr->m_ti, child, std::move(child_state), index, children_count, TVI_FIRST);
         }

--- a/foo_uie_albumlist/tree_view_populator.cpp
+++ b/foo_uie_albumlist/tree_view_populator.cpp
@@ -27,20 +27,14 @@ void TreeViewPopulator::setup_tree(HTREEITEM parent, node_ptr ptr, std::optional
     ptr->purge_empty_children(m_wnd_tv);
 
     if ((!ptr->m_ti || ptr->m_label_dirty) && (ptr->m_level > 0 || cfg_show_root_node)) {
-        auto text = m_node_formatter.format(ptr, idx, max_idx);
+        ptr->set_display_index(idx);
 
-        if (ptr->m_ti) {
-            TVITEMEX tvi{};
-            tvi.hItem = ptr->m_ti;
-            tvi.mask = TVIF_TEXT;
-            tvi.pszText = const_cast<WCHAR*>(text);
-            TreeView_SetItem(m_wnd_tv, &tvi);
-        } else {
+        if (!ptr->m_ti) {
             TVINSERTSTRUCT is{};
             is.hParent = parent;
             is.hInsertAfter = ti_after;
             is.item.mask = TVIF_TEXT | TVIF_PARAM | TVIF_STATE;
-            is.item.pszText = const_cast<WCHAR*>(text);
+            is.item.pszText = LPSTR_TEXTCALLBACK;
             is.item.lParam = reinterpret_cast<LPARAM>(ptr.get());
             is.item.state = expanded ? TVIS_EXPANDED : 0;
             is.item.stateMask = TVIS_EXPANDED;


### PR DESCRIPTION
This makes performance improvements in a number of areas:

- keeping UTF-16 node names in memory to speed up handling of items being added to the library after tree population (at the cost of increased memory usage)
- inserting tree items in reverse order even when there are existing items in the tree
- avoiding modifying tree items when the display text of an item changes, by making the tree view request item text when it needs it
- delaying panel initialisation on foobar2000 2.0 and newer until after the media library has initialised
- recreating the tree view window on view changes instead of deleting all items and repopulating, as deleting all items is slow