### PR TITLE
Fix preservation of expansion state with auto-collapse enabled

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -592,6 +592,25 @@ bool album_list_window::do_click_action(ClickAction click_action)
     return true;
 }
 
+void album_list_window::collapse_other_nodes(const node_ptr& node) const
+{
+    auto current = node;
+    auto parent = current->get_parent().lock();
+
+    while (parent) {
+        auto expanded_siblings = parent->get_children()
+            | ranges::views::filter([&current](auto& sibling) { return sibling->is_expanded() && sibling != current; });
+
+        for (const auto& sibling : expanded_siblings) {
+            TreeView_Expand(m_wnd_tv, sibling->m_ti, TVE_COLLAPSE);
+            sibling->set_expanded(false);
+        }
+
+        current = parent;
+        parent = current->get_parent().lock();
+    }
+}
+
 // {606E9CDD-45EE-4c3b-9FD5-49381CEBE8AE}
 const GUID album_list_window::s_extension_guid
     = {0x606e9cdd, 0x45ee, 0x4c3b, {0x9f, 0xd5, 0x49, 0x38, 0x1c, 0xeb, 0xe8, 0xae}};

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -119,6 +119,7 @@ private:
     static inline wil::unique_hbrush s_filter_background_brush;
 
     bool do_click_action(ClickAction click_action);
+    void collapse_other_nodes(const node_ptr& node) const;
 
     HWND m_wnd_tv{nullptr};
     HWND m_wnd_edit{nullptr};

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -281,7 +281,7 @@ std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
         }
 
         if (cfg_collapse_other_nodes_on_expansion && param->action == TVE_EXPAND) {
-            uih::tree_view_collapse_other_nodes(param->hdr.hwndFrom, param->itemNew.hItem);
+            collapse_other_nodes(p_node);
         }
         break;
     }

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 #include "node_state.h"
 
 typedef std::shared_ptr<class node> node_ptr;


### PR DESCRIPTION
This fixes a problem where expansion state was incorrectly restored if 'Auto-collapse on item expansion' was enabled. This was because the internal expansion state was not updated correctly when auto-collapsing nodes.