### PR TITLE
Use UpperCamelCase for classes

### DIFF
--- a/foo_uie_albumlist/config.cpp
+++ b/foo_uie_albumlist/config.cpp
@@ -11,7 +11,7 @@ struct {
         "[%album artist% - ]['['%date%']' ]%album%|[[%discnumber%.]%tracknumber%. ][%track artist% - ]%title%"},
 };
 
-cfg_view_list_t cfg_views(GUID{0xc584d488, 0x53dd, 0x4d21, 0xa8, 0x5b, 0x8e, 0xc7, 0xcc, 0xb3, 0x82, 0x16});
+CfgViewList cfg_views(GUID{0xc584d488, 0x53dd, 0x4d21, 0xa8, 0x5b, 0x8e, 0xc7, 0xcc, 0xb3, 0x82, 0x16});
 
 cfg_string cfg_autosend_playlist_name(
     GUID{0x4beb593f, 0xa010, 0x8b3a, 0x7b, 0x2a, 0x63, 0xad, 0xf3, 0x9f, 0xc6, 0xb4}, "Library view");
@@ -42,7 +42,7 @@ cfg_int cfg_add_items_select(GUID{0x3918ae65, 0xfdfb, 0xe23e, 0xfc, 0x3b, 0xee, 
 cfg_int cfg_collapse_other_nodes_on_expansion(
     GUID{0x2a9d24a2, 0x2705, 0xb35e, 0xdb, 0x20, 0x86, 0xc6, 0x90, 0xc6, 0xe9, 0x4c}, 0);
 
-void cfg_view_list_t::get_data_raw(stream_writer* out, abort_callback& p_abort)
+void CfgViewList::get_data_raw(stream_writer* out, abort_callback& p_abort)
 {
     const auto item_count = m_data.get_count();
     out->write_lendian_t(item_count, p_abort);
@@ -52,7 +52,7 @@ void cfg_view_list_t::get_data_raw(stream_writer* out, abort_callback& p_abort)
     }
 }
 
-void cfg_view_list_t::set_data_raw(stream_reader* r, size_t psize, abort_callback& p_abort)
+void CfgViewList::set_data_raw(stream_reader* r, size_t psize, abort_callback& p_abort)
 {
     m_data.remove_all();
     size_t item_count{0};
@@ -65,7 +65,7 @@ void cfg_view_list_t::set_data_raw(stream_reader* r, size_t psize, abort_callbac
     }
 }
 
-void cfg_view_list_t::reset()
+void CfgViewList::reset()
 {
     m_data.remove_all();
     for (size_t i{0}; i < tabsize(cfg_view_list_defaults); ++i) {

--- a/foo_uie_albumlist/config.h
+++ b/foo_uie_albumlist/config.h
@@ -1,6 +1,6 @@
 #pragma once
 
-class cfg_view_list_t : public cfg_var {
+class CfgViewList : public cfg_var {
 public:
     void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* r, size_t psize, abort_callback& p_abort) override;
@@ -48,7 +48,7 @@ public:
 
     void swap(size_t index1, size_t index2) { m_data.swap_items(index1, index2); }
 
-    cfg_view_list_t(const GUID& p_guid) : cfg_var(p_guid) { reset(); }
+    CfgViewList(const GUID& p_guid) : cfg_var(p_guid) { reset(); }
 
     void format_display(size_t index, pfc::string_base& out) const
     {
@@ -74,7 +74,7 @@ constexpr GUID album_list_filter_colours_client_id{
 constexpr GUID album_list_panel_preferences_page_id{
     0x53c89e50, 0x685d, 0x8ed1, 0x43, 0x25, 0x6b, 0xe8, 0x0f, 0x1b, 0xe7, 0x1f};
 
-extern cfg_view_list_t cfg_views;
+extern CfgViewList cfg_views;
 extern cfg_bool cfg_themed;
 extern cfg_int cfg_populate_on_init;
 extern cfg_int cfg_autosend;

--- a/foo_uie_albumlist/fcl.cpp
+++ b/foo_uie_albumlist/fcl.cpp
@@ -12,7 +12,7 @@ const GUID g_guid_fcl_dataset_album_list_views{
 const GUID g_guid_fcl_dataset_album_list_appearance{
     0xe93df451, 0x6196, 0x48fd, {0xa6, 0x7b, 0xf9, 0x5, 0x67, 0x5, 0x33, 0x6a}};
 
-class album_list_fcl_views : public cui::fcl::dataset {
+class AlbumListViewsDataSet : public cui::fcl::dataset {
 public:
     void get_name(pfc::string_base& p_out) const override { p_out = "Album List Views"; }
     const GUID& get_guid() const override { return g_guid_fcl_dataset_album_list_views; }
@@ -48,7 +48,7 @@ public:
         }
         if (g_config_general.is_active())
             g_config_general.refresh_views();
-        album_list_window::s_refresh_all();
+        AlbumListWindow::s_refresh_all();
     }
 
 private:
@@ -89,7 +89,7 @@ private:
     }
 };
 
-class album_list_fcl_appearance : public cui::fcl::dataset {
+class AlbumListAppearanceDataSet : public cui::fcl::dataset {
 public:
     void get_name(pfc::string_base& p_out) const override { p_out = "Album List appearance settings"; }
     const GUID& get_guid() const override { return g_guid_fcl_dataset_album_list_appearance; }
@@ -121,9 +121,9 @@ public:
         const auto version = fcl_reader.read_raw_item<uint32_t>();
         if (version <= stream_version) {
             read_items(fcl_reader);
-            album_list_window::s_update_all_item_heights();
-            album_list_window::s_update_all_indents();
-            album_list_window::s_update_all_window_frames();
+            AlbumListWindow::s_update_all_item_heights();
+            AlbumListWindow::s_update_all_indents();
+            AlbumListWindow::s_update_all_window_frames();
         }
     }
 
@@ -211,5 +211,5 @@ private:
 cui::fcl::group_impl_factory g_fclgroup{g_guid_fcl_group_album_list_views, "Album List Views",
     "Album List view title format scripts", cui::fcl::groups::title_scripts};
 
-cui::fcl::dataset_factory<album_list_fcl_views> g_album_list_fcl_views;
-cui::fcl::dataset_factory<album_list_fcl_appearance> g_album_list_fcl_appearance;
+cui::fcl::dataset_factory<AlbumListViewsDataSet> g_album_list_fcl_views;
+cui::fcl::dataset_factory<AlbumListAppearanceDataSet> g_album_list_fcl_appearance;

--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -22,7 +22,7 @@ DECLARE_COMPONENT_VERSION("Album list panel",
 
 const char* directory_structure_view_name = "by directory structure";
 
-void album_list_window::s_update_all_fonts()
+void AlbumListWindow::s_update_all_fonts()
 {
     if (s_font) {
         const auto count = s_instances.get_count();
@@ -55,7 +55,7 @@ void album_list_window::s_update_all_fonts()
     }
 }
 
-album_list_window::~album_list_window()
+AlbumListWindow::~AlbumListWindow()
 {
     if (m_initialised) {
         s_instances.remove_item(this);
@@ -63,7 +63,7 @@ album_list_window::~album_list_window()
     }
 }
 
-void album_list_window::s_update_all_window_frames()
+void AlbumListWindow::s_update_all_window_frames()
 {
     long flags = 0;
     if (cfg_frame_style == 1)
@@ -82,7 +82,7 @@ void album_list_window::s_update_all_window_frames()
     }
 }
 
-void album_list_window::s_update_all_tree_colours()
+void AlbumListWindow::s_update_all_tree_colours()
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -93,7 +93,7 @@ void album_list_window::s_update_all_tree_colours()
     }
 }
 
-void album_list_window::s_update_all_tree_themes()
+void AlbumListWindow::s_update_all_tree_themes()
 {
     for (auto&& window : s_instances) {
         window->update_tree_theme();
@@ -101,13 +101,13 @@ void album_list_window::s_update_all_tree_themes()
     }
 }
 
-void album_list_window::s_update_all_edit_themes()
+void AlbumListWindow::s_update_all_edit_themes()
 {
     for (auto&& window : s_instances)
         window->update_edit_theme();
 }
 
-void album_list_window::s_update_all_edit_colours()
+void AlbumListWindow::s_update_all_edit_colours()
 {
     s_filter_background_brush.reset();
 
@@ -115,7 +115,7 @@ void album_list_window::s_update_all_edit_colours()
         window->update_edit_colours();
 }
 
-void album_list_window::s_update_all_labels()
+void AlbumListWindow::s_update_all_labels()
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -126,13 +126,13 @@ void album_list_window::s_update_all_labels()
     }
 }
 
-void album_list_window::s_mark_tracks_unsorted()
+void AlbumListWindow::s_mark_tracks_unsorted()
 {
     for (const auto& instance : s_instances)
         instance->mark_tracks_unsorted();
 }
 
-void album_list_window::s_update_all_showhscroll()
+void AlbumListWindow::s_update_all_showhscroll()
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -144,7 +144,7 @@ void album_list_window::s_update_all_showhscroll()
     }
 }
 
-void album_list_window::s_on_view_script_change(const char* p_view_before, const char* p_view)
+void AlbumListWindow::s_on_view_script_change(const char* p_view_before, const char* p_view)
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -155,7 +155,7 @@ void album_list_window::s_on_view_script_change(const char* p_view_before, const
     }
 }
 
-void album_list_window::s_refresh_all()
+void AlbumListWindow::s_refresh_all()
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -166,7 +166,7 @@ void album_list_window::s_refresh_all()
     }
 }
 
-void album_list_window::s_update_all_item_heights()
+void AlbumListWindow::s_update_all_item_heights()
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -177,7 +177,7 @@ void album_list_window::s_update_all_item_heights()
     }
 }
 
-void album_list_window::s_update_all_indents()
+void AlbumListWindow::s_update_all_indents()
 {
     const auto count = s_instances.get_count();
     for (size_t i{0}; i < count; i++) {
@@ -189,12 +189,12 @@ void album_list_window::s_update_all_indents()
     }
 }
 
-bool album_list_window::is_bydir() const
+bool AlbumListWindow::is_bydir() const
 {
     return !stricmp_utf8(m_view, directory_structure_view_name);
 }
 
-const char* album_list_window::get_hierarchy() const
+const char* AlbumListWindow::get_hierarchy() const
 {
     const auto index = cfg_views.find_item(m_view);
     if (index != pfc_infinite)
@@ -202,7 +202,7 @@ const char* album_list_window::get_hierarchy() const
     return "N/A";
 }
 
-void album_list_window::on_view_script_change(const char* p_view_before, const char* p_view)
+void AlbumListWindow::on_view_script_change(const char* p_view_before, const char* p_view)
 {
     if (get_wnd()) {
         if (!stricmp_utf8(p_view_before, m_view)) {
@@ -211,7 +211,7 @@ void album_list_window::on_view_script_change(const char* p_view_before, const c
     }
 }
 
-void album_list_window::update_all_labels() const
+void AlbumListWindow::update_all_labels() const
 {
     if (m_root) {
         m_root->mark_all_labels_dirty();
@@ -221,13 +221,13 @@ void album_list_window::update_all_labels() const
     }
 }
 
-void album_list_window::mark_tracks_unsorted() const
+void AlbumListWindow::mark_tracks_unsorted() const
 {
     if (m_root)
         m_root->mark_tracks_unsorted();
 }
 
-void album_list_window::update_tree_theme(const cui::colours::helper& colours) const
+void AlbumListWindow::update_tree_theme(const cui::colours::helper& colours) const
 {
     if (!m_wnd_tv)
         return;
@@ -254,7 +254,7 @@ void album_list_window::update_tree_theme(const cui::colours::helper& colours) c
     SetWindowLongPtr(m_wnd_tv, GWL_STYLE, styles);
 }
 
-void album_list_window::update_tree_colours()
+void AlbumListWindow::update_tree_colours()
 {
     SetWindowRedraw(m_wnd_tv, FALSE);
     cui::colours::helper p_colours(album_list_items_colours_client_id);
@@ -267,7 +267,7 @@ void album_list_window::update_tree_colours()
     SetWindowRedraw(m_wnd_tv, TRUE);
 }
 
-void album_list_window::update_tooltip_theme() const
+void AlbumListWindow::update_tooltip_theme() const
 {
     if (!m_wnd_tv)
         return;
@@ -281,7 +281,7 @@ void album_list_window::update_tooltip_theme() const
     SetWindowTheme(tooltip_wnd, is_dark ? L"DarkMode_Explorer" : nullptr, nullptr);
 }
 
-void album_list_window::update_edit_theme() const
+void AlbumListWindow::update_edit_theme() const
 {
     if (!m_wnd_edit)
         return;
@@ -289,7 +289,7 @@ void album_list_window::update_edit_theme() const
     SetWindowTheme(m_wnd_edit, cui::colours::is_dark_mode_active() ? L"DarkMode_CFD" : nullptr, nullptr);
 }
 
-void album_list_window::update_edit_colours() const
+void AlbumListWindow::update_edit_colours() const
 {
     if (!m_wnd_edit)
         return;
@@ -297,7 +297,7 @@ void album_list_window::update_edit_colours() const
     RedrawWindow(m_wnd_edit, nullptr, nullptr, RDW_ERASE | RDW_INVALIDATE);
 }
 
-void album_list_window::update_item_height()
+void AlbumListWindow::update_item_height()
 {
     const auto font = uih::get_window_font(m_wnd_tv);
     int font_height = -1;
@@ -309,13 +309,13 @@ void album_list_window::update_item_height()
     TreeView_SetItemHeight(m_wnd_tv, font_height);
 }
 
-void album_list_window::on_task_completion(t_uint32 task, t_uint32 code)
+void AlbumListWindow::on_task_completion(t_uint32 task, t_uint32 code)
 {
     if (task == 0)
         refresh_tree();
 }
 
-void album_list_window::create_or_destroy_filter()
+void AlbumListWindow::create_or_destroy_filter()
 {
     if (m_filter)
         create_filter();
@@ -324,7 +324,7 @@ void album_list_window::create_or_destroy_filter()
     on_size();
 }
 
-void album_list_window::create_filter()
+void AlbumListWindow::create_filter()
 {
     if (m_filter && !m_wnd_edit) {
         const auto flags = WS_EX_CLIENTEDGE;
@@ -337,7 +337,7 @@ void album_list_window::create_filter()
     }
 }
 
-void album_list_window::destroy_filter()
+void AlbumListWindow::destroy_filter()
 {
     if (m_wnd_edit) {
         const auto was_focused = GetFocus() == m_wnd_edit;
@@ -354,7 +354,7 @@ void album_list_window::destroy_filter()
     m_filter_ptr.release();
 }
 
-void album_list_window::on_size(unsigned cx, unsigned cy)
+void AlbumListWindow::on_size(unsigned cx, unsigned cy)
 {
     HDWP dwp = BeginDeferWindowPos(2);
     const unsigned edit_height = m_wnd_edit ? uGetFontHeight(s_font.get()) + 4 : 0;
@@ -366,14 +366,14 @@ void album_list_window::on_size(unsigned cx, unsigned cy)
     EndDeferWindowPos(dwp);
 }
 
-void album_list_window::on_size()
+void AlbumListWindow::on_size()
 {
     RECT rc;
     GetClientRect(get_wnd(), &rc);
     on_size(rc.right, rc.bottom);
 }
 
-void album_list_window::create_tree()
+void AlbumListWindow::create_tree()
 {
     const auto wnd = get_wnd();
 
@@ -419,7 +419,7 @@ void album_list_window::create_tree()
     }
 }
 
-void album_list_window::destroy_tree(bool should_save_scroll_position)
+void AlbumListWindow::destroy_tree(bool should_save_scroll_position)
 {
     if (m_wnd_tv) {
         if (should_save_scroll_position)
@@ -430,7 +430,7 @@ void album_list_window::destroy_tree(bool should_save_scroll_position)
     }
 }
 
-void album_list_window::recreate_tree(bool save_state)
+void AlbumListWindow::recreate_tree(bool save_state)
 {
     if (!m_wnd_tv)
         return;
@@ -448,7 +448,7 @@ void album_list_window::recreate_tree(bool save_state)
     RedrawWindow(get_wnd(), nullptr, nullptr, RDW_INVALIDATE | RDW_ALLCHILDREN);
 }
 
-void album_list_window::save_scroll_position() const
+void AlbumListWindow::save_scroll_position() const
 {
     if (!m_wnd_tv)
         return;
@@ -469,7 +469,7 @@ void album_list_window::save_scroll_position() const
     m_saved_scroll_position = {si_horz.nPos, si_vert.nPos, si_vert.nMax};
 }
 
-void album_list_window::restore_scroll_position()
+void AlbumListWindow::restore_scroll_position()
 {
     if (!m_wnd_tv || !m_saved_scroll_position)
         return;
@@ -501,7 +501,7 @@ void album_list_window::restore_scroll_position()
     m_saved_scroll_position.reset();
 }
 
-void album_list_window::get_config(stream_writer* p_writer, abort_callback& p_abort) const
+void AlbumListWindow::get_config(stream_writer* p_writer, abort_callback& p_abort) const
 {
     save_scroll_position();
 
@@ -519,17 +519,17 @@ void album_list_window::get_config(stream_writer* p_writer, abort_callback& p_ab
     }
 }
 
-void album_list_window::get_name(pfc::string_base& out) const
+void AlbumListWindow::get_name(pfc::string_base& out) const
 {
     out.set_string("Album list");
 }
 
-void album_list_window::get_category(pfc::string_base& out) const
+void AlbumListWindow::get_category(pfc::string_base& out) const
 {
     out.set_string("Panels");
 }
 
-void album_list_window::set_config(stream_reader* p_reader, t_size psize, abort_callback& p_abort)
+void AlbumListWindow::set_config(stream_reader* p_reader, t_size psize, abort_callback& p_abort)
 {
     if (psize) {
         p_reader->read_string(m_view, p_abort);
@@ -548,38 +548,38 @@ void album_list_window::set_config(stream_reader* p_reader, t_size psize, abort_
     }
 }
 
-void album_list_window::toggle_show_filter()
+void AlbumListWindow::toggle_show_filter()
 {
     m_filter = !m_filter;
     create_or_destroy_filter();
 }
 
-const char* album_list_window::get_view() const
+const char* AlbumListWindow::get_view() const
 {
     return m_view;
 }
 
-void album_list_window::set_view(const char* view)
+void AlbumListWindow::set_view(const char* view)
 {
     m_view = view;
     recreate_tree(false);
 }
 
-void album_list_window::get_menu_items(ui_extension::menu_hook_t& p_hook)
+void AlbumListWindow::get_menu_items(ui_extension::menu_hook_t& p_hook)
 {
     const auto node_settings
         = uie::menu_node_ptr{new uie::simple_command_menu_node{"Settings", "Shows Album List panel settings", 0,
             [] { static_api_ptr_t<ui_control>()->show_preferences(album_list_panel_preferences_page_id); }}};
     const auto node_filter = uie::menu_node_ptr{new uie::simple_command_menu_node{"Filter", "Shows the filter bar",
         m_filter ? uie::menu_node_t::state_checked : 0,
-        [instance = service_ptr_t<album_list_window>{this}] { instance->toggle_show_filter(); }}};
+        [instance = service_ptr_t<AlbumListWindow>{this}] { instance->toggle_show_filter(); }}};
 
-    p_hook.add_node(ui_extension::menu_node_ptr(new menu_node_select_view(this)));
+    p_hook.add_node(ui_extension::menu_node_ptr(new MenuNodeSelectView(this)));
     p_hook.add_node(node_filter);
     p_hook.add_node(node_settings);
 }
 
-bool album_list_window::do_click_action(ClickAction click_action)
+bool AlbumListWindow::do_click_action(ClickAction click_action)
 {
     auto cleaned_selection = get_cleaned_selection();
 
@@ -602,7 +602,7 @@ bool album_list_window::do_click_action(ClickAction click_action)
     return true;
 }
 
-void album_list_window::collapse_other_nodes(const node_ptr& node) const
+void AlbumListWindow::collapse_other_nodes(const node_ptr& node) const
 {
     auto current = node;
     auto parent = current->get_parent();
@@ -621,18 +621,18 @@ void album_list_window::collapse_other_nodes(const node_ptr& node) const
     }
 }
 
-void album_list_window::deselect_selected_nodes(const node_ptr& skip) const
+void AlbumListWindow::deselect_selected_nodes(const node_ptr& skip) const
 {
     const auto selection = m_selection;
-    for (auto& node_ : selection) {
-        if (skip && node_ == skip)
+    for (auto& node : selection) {
+        if (skip && node == skip)
             continue;
 
-        manually_select_tree_item(node_->m_ti, false);
+        manually_select_tree_item(node->m_ti, false);
     }
 }
 
-void album_list_window::delete_all_nodes()
+void AlbumListWindow::delete_all_nodes()
 {
     TreeView_DeleteAllItems(m_wnd_tv);
     m_selection.clear();
@@ -640,7 +640,7 @@ void album_list_window::delete_all_nodes()
     m_root.reset();
 }
 
-node_ptr album_list_window::get_node_for_tree_item(HTREEITEM item) const
+node_ptr AlbumListWindow::get_node_for_tree_item(HTREEITEM item) const
 {
     TVITEMEX tvi{};
     tvi.hItem = item;
@@ -648,10 +648,10 @@ node_ptr album_list_window::get_node_for_tree_item(HTREEITEM item) const
     if (!TreeView_GetItem(m_wnd_tv, &tvi))
         return {};
 
-    return reinterpret_cast<node*>(tvi.lParam)->shared_from_this();
+    return reinterpret_cast<Node*>(tvi.lParam)->shared_from_this();
 }
 
-bool album_list_window::manually_select_tree_item(HTREEITEM item, bool selected) const
+bool AlbumListWindow::manually_select_tree_item(HTREEITEM item, bool selected) const
 {
     TVITEMEX tvi{};
     tvi.hItem = item;
@@ -661,7 +661,7 @@ bool album_list_window::manually_select_tree_item(HTREEITEM item, bool selected)
     return TreeView_SetItem(m_wnd_tv, &tvi) != 0;
 }
 
-void album_list_window::select_range(const node_ptr& from, const node_ptr& to, bool expand) const
+void AlbumListWindow::select_range(const node_ptr& from, const node_ptr& to, bool expand) const
 {
     std::unordered_set new_selection{to, from};
     const auto old_selection = m_selection;
@@ -685,11 +685,11 @@ void album_list_window::select_range(const node_ptr& from, const node_ptr& to, b
 
         HTREEITEM item = from->m_ti;
         while ((item = TreeView_GetNextItem(m_wnd_tv, item, next_item_arg)) != to->m_ti && item) {
-            if (auto node_ = get_node_for_tree_item(item)) {
-                if (!m_selection.contains(node_))
+            if (auto node = get_node_for_tree_item(item)) {
+                if (!m_selection.contains(node))
                     manually_select_tree_item(item, true);
 
-                new_selection.emplace(node_);
+                new_selection.emplace(node);
             }
         }
     }
@@ -697,27 +697,27 @@ void album_list_window::select_range(const node_ptr& from, const node_ptr& to, b
     if (!expand) {
         std::vector<node_ptr> to_deselect{};
         ranges::copy_if(old_selection, std::back_inserter(to_deselect),
-            [&new_selection](auto& node_) { return !new_selection.contains(node_); });
+            [&new_selection](auto& node) { return !new_selection.contains(node); });
 
-        for (const auto& node_ : to_deselect) {
-            manually_select_tree_item(node_->m_ti, false);
+        for (const auto& node : to_deselect) {
+            manually_select_tree_item(node->m_ti, false);
         }
     }
 }
 
-void album_list_window::autosend()
+void AlbumListWindow::autosend()
 {
     if (cfg_autosend)
         alp::send_nodes_to_autosend_playlist(get_cleaned_selection(), m_view, false);
 }
 
-void album_list_window::update_selection_holder()
+void AlbumListWindow::update_selection_holder()
 {
     if (m_selection_holder.is_valid())
         m_selection_holder->set_selection(alp::get_node_tracks(get_cleaned_selection()).tracks());
 }
 
-const std::vector<node_ptr>& album_list_window::get_cleaned_selection()
+const std::vector<node_ptr>& AlbumListWindow::get_cleaned_selection()
 {
     if (!m_cleaned_selection)
         m_cleaned_selection = alp::clean_selection(m_selection);
@@ -726,7 +726,7 @@ const std::vector<node_ptr>& album_list_window::get_cleaned_selection()
 }
 
 // {606E9CDD-45EE-4c3b-9FD5-49381CEBE8AE}
-const GUID album_list_window::s_extension_guid
+const GUID AlbumListWindow::s_extension_guid
     = {0x606e9cdd, 0x45ee, 0x4c3b, {0x9f, 0xd5, 0x49, 0x38, 0x1c, 0xeb, 0xe8, 0xae}};
 
-ui_extension::window_factory<album_list_window> blah;
+ui_extension::window_factory<AlbumListWindow> blah;

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -28,12 +28,12 @@ enum class ClickAction {
     send_to_autosend_playlist
 };
 
-class album_list_window
+class AlbumListWindow
     : public uie::container_uie_window_v3
     , public library_callback_dynamic
     , public library_callback_v2_dynamic {
     friend class font_notify;
-    friend class node;
+    friend class Node;
 
 public:
     static void s_update_all_tree_colours();
@@ -50,7 +50,7 @@ public:
     static void s_on_view_script_change(const char* p_view_before, const char* p_view);
     static void s_update_all_window_frames();
 
-    ~album_list_window();
+    ~AlbumListWindow();
 
     bool is_bydir() const;
     const char* get_hierarchy() const;
@@ -117,7 +117,7 @@ private:
     LRESULT WINAPI on_tree_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     std::optional<LRESULT> on_tree_lbuttondown(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
-    static inline pfc::ptr_list_t<album_list_window> s_instances;
+    static inline pfc::ptr_list_t<AlbumListWindow> s_instances;
     static const GUID s_extension_guid;
     static const char* s_class_name;
     static inline wil::unique_hfont s_font;
@@ -153,7 +153,7 @@ private:
     mutable std::optional<alp::SavedScrollPosition> m_saved_scroll_position{};
     pfc::string8 m_view{"by artist/album"};
     node_ptr m_root;
-    std::weak_ptr<node> m_shift_start;
+    std::weak_ptr<Node> m_shift_start;
     std::optional<std::vector<node_ptr>> m_cleaned_selection;
     std::unordered_set<node_ptr> m_selection;
     std::optional<alp::SavedNodeState> m_node_state;

--- a/foo_uie_albumlist/main_hook_proc.cpp
+++ b/foo_uie_albumlist/main_hook_proc.cpp
@@ -3,9 +3,9 @@
 #include "node.h"
 #include "node_utils.h"
 
-LRESULT WINAPI album_list_window::s_tree_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI AlbumListWindow::s_tree_hook_proc(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
-    auto p_this = reinterpret_cast<album_list_window*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
+    auto p_this = reinterpret_cast<AlbumListWindow*>(GetWindowLongPtr(wnd, GWLP_USERDATA));
 
     return p_this ? p_this->on_tree_hooked_message(wnd, msg, wp, lp) : DefWindowProc(wnd, msg, wp, lp);
 }
@@ -17,7 +17,7 @@ static bool test_point_distance(POINT pt1, POINT pt2, int test)
     return dx * dx + dy * dy > test * test;
 }
 
-LRESULT WINAPI album_list_window::on_tree_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT WINAPI AlbumListWindow::on_tree_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_KEYDOWN:
@@ -229,7 +229,7 @@ LRESULT WINAPI album_list_window::on_tree_hooked_message(HWND wnd, UINT msg, WPA
     return CallWindowProc(m_treeproc, wnd, msg, wp, lp);
 }
 
-std::optional<LRESULT> album_list_window::on_tree_lbuttondown(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+std::optional<LRESULT> AlbumListWindow::on_tree_lbuttondown(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     m_clicked = true;
     m_clickpoint = {GET_X_LPARAM(lp), GET_Y_LPARAM(lp)};

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -3,7 +3,7 @@
 #include "node_utils.h"
 #include "tree_view_populator.h"
 
-LRESULT album_list_window::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+LRESULT AlbumListWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_CREATE: {
@@ -125,7 +125,7 @@ LRESULT album_list_window::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     return DefWindowProc(wnd, msg, wp, lp);
 }
 
-LRESULT album_list_window::on_wm_contextmenu(POINT pt)
+LRESULT AlbumListWindow::on_wm_contextmenu(POINT pt)
 {
     enum {
         ID_SEND = 1,
@@ -196,7 +196,7 @@ LRESULT album_list_window::on_wm_contextmenu(POINT pt)
     tvi.hItem = treeitem;
     tvi.mask = TVIF_HANDLE | TVIF_PARAM;
     TreeView_GetItem(m_wnd_tv, &tvi);
-    auto click_node = treeitem && tvi.lParam ? reinterpret_cast<node*>(tvi.lParam)->shared_from_this() : nullptr;
+    auto click_node = treeitem && tvi.lParam ? reinterpret_cast<Node*>(tvi.lParam)->shared_from_this() : nullptr;
 
     std::vector<node_ptr> nodes;
     if (click_node && m_selection.contains(click_node))
@@ -271,7 +271,7 @@ LRESULT album_list_window::on_wm_contextmenu(POINT pt)
     return 0;
 }
 
-std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
+std::optional<LRESULT> AlbumListWindow::on_tree_view_wm_notify(LPNMHDR hdr)
 {
     switch (hdr->code) {
     case TVN_ITEMCHANGING: {
@@ -289,27 +289,27 @@ std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
         if (was_selected == is_selected)
             break;
 
-        auto node_ = reinterpret_cast<node*>(nmtvic->lParam)->shared_from_this();
+        auto node = reinterpret_cast<Node*>(nmtvic->lParam)->shared_from_this();
 
         m_cleaned_selection.reset();
 
         if (is_selected)
-            m_selection.emplace(node_);
+            m_selection.emplace(node);
         else
-            m_selection.erase(node_);
+            m_selection.erase(node);
 
         break;
     }
     case TVN_GETDISPINFO: {
         auto param = reinterpret_cast<LPNMTVDISPINFO>(hdr);
-        node_ptr p_node = reinterpret_cast<node*>(param->item.lParam)->shared_from_this();
+        node_ptr p_node = reinterpret_cast<Node*>(param->item.lParam)->shared_from_this();
         auto text = m_node_formatter.format(p_node);
         wcscpy_s(param->item.pszText, param->item.cchTextMax, text);
         break;
     }
     case TVN_ITEMEXPANDING: {
         auto param = reinterpret_cast<LPNMTREEVIEW>(hdr);
-        node_ptr p_node = reinterpret_cast<node*>(param->itemNew.lParam)->shared_from_this();
+        node_ptr p_node = reinterpret_cast<Node*>(param->itemNew.lParam)->shared_from_this();
 
         if (!p_node->m_children_inserted) {
             TreeViewPopulator::s_setup_children(m_wnd_tv, p_node);
@@ -323,7 +323,7 @@ std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
     }
     case TVN_ITEMEXPANDED: {
         auto param = reinterpret_cast<LPNMTREEVIEW>(hdr);
-        node_ptr p_node = reinterpret_cast<node*>(param->itemNew.lParam)->shared_from_this();
+        node_ptr p_node = reinterpret_cast<Node*>(param->itemNew.lParam)->shared_from_this();
         p_node->set_expanded((param->action & TVE_EXPAND) != 0);
         break;
     }
@@ -332,8 +332,8 @@ std::optional<LRESULT> album_list_window::on_tree_view_wm_notify(LPNMHDR hdr)
             break;
 
         const auto nmtv = reinterpret_cast<LPNMTREEVIEW>(hdr);
-        node_ptr node_ = reinterpret_cast<node*>(nmtv->itemNew.lParam)->shared_from_this();
-        deselect_selected_nodes(node_);
+        const node_ptr node = reinterpret_cast<Node*>(nmtv->itemNew.lParam)->shared_from_this();
+        deselect_selected_nodes(node);
         break;
     }
     case TVN_SELCHANGED: {

--- a/foo_uie_albumlist/menu.h
+++ b/foo_uie_albumlist/menu.h
@@ -1,8 +1,8 @@
 #pragma once
 
-class menu_node_select_view : public ui_extension::menu_node_popup_t {
+class MenuNodeSelectView : public ui_extension::menu_node_popup_t {
     pfc::list_t<ui_extension::menu_node_ptr> m_items;
-    service_ptr_t<album_list_window> m_window;
+    service_ptr_t<AlbumListWindow> m_window;
 
 public:
     bool get_display_data(pfc::string_base& p_out, unsigned& p_displayflags) const override
@@ -16,7 +16,7 @@ public:
 
     void get_child(size_t p_index, uie::menu_node_ptr& p_out) const override { p_out = m_items[p_index].get_ptr(); }
 
-    menu_node_select_view(album_list_window* p_wnd) : m_window{p_wnd}
+    MenuNodeSelectView(AlbumListWindow* p_wnd) : m_window{p_wnd}
     {
         const auto view_count = cfg_views.get_count();
         add_item(directory_structure_view_name);

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -2,17 +2,17 @@
 
 #include "node_state.h"
 
-typedef std::shared_ptr<class node> node_ptr;
+typedef std::shared_ptr<class Node> node_ptr;
 
-class node : public std::enable_shared_from_this<node> {
+class Node : public std::enable_shared_from_this<Node> {
 public:
     HTREEITEM m_ti{};
     bool m_label_dirty{};
     bool m_children_inserted{};
     uint16_t m_level;
 
-    node(const char* name, size_t name_length, class album_list_window* window, uint16_t level,
-        std::weak_ptr<node> parent = {});
+    Node(const char* name, size_t name_length, class AlbumListWindow* window, uint16_t level,
+        std::weak_ptr<Node> parent = {});
 
     void sort_children();
 
@@ -25,7 +25,7 @@ public:
 
     void set_bydir(bool p) { m_bydir = p; }
 
-    ~node()
+    ~Node()
     {
         m_tracks.remove_all();
         m_children.clear();
@@ -87,7 +87,7 @@ public:
 
 private:
     void sort_tracks();
-    void apply_function(std::function<void(node&)> func)
+    void apply_function(std::function<void(Node&)> func)
     {
         func(*this);
 
@@ -95,7 +95,7 @@ private:
             child->apply_function(func);
     }
 
-    std::weak_ptr<node> m_parent;
+    std::weak_ptr<Node> m_parent;
     std::optional<size_t> m_display_index;
     pfc::string_simple m_name;
     pfc::stringcvt::string_wide_from_utf8 m_name_utf16;
@@ -104,5 +104,5 @@ private:
     bool m_sorted : 1 {};
     bool m_bydir : 1 {};
     bool m_expanded : 1 {};
-    class album_list_window* m_window{};
+    class AlbumListWindow* m_window{};
 };

--- a/foo_uie_albumlist/node_utils.cpp
+++ b/foo_uie_albumlist/node_utils.cpp
@@ -11,9 +11,9 @@ std::vector<node_ptr> clean_selection(std::unordered_set<node_ptr> selection)
 {
     std::vector<node_ptr> cleaned_selection;
 
-    for (auto& node_ : selection) {
-        if (!ranges::any_of(node_->get_parents(), [&selection](auto& parent) { return selection.contains(parent); }))
-            cleaned_selection.emplace_back(node_);
+    for (auto& node : selection) {
+        if (!ranges::any_of(node->get_parents(), [&selection](auto& parent) { return selection.contains(parent); }))
+            cleaned_selection.emplace_back(node);
     }
 
     ranges::sort(cleaned_selection, [](auto& left, auto& right) {
@@ -23,7 +23,7 @@ std::vector<node_ptr> clean_selection(std::unordered_set<node_ptr> selection)
         auto left_hierarchy = left->get_hierarchy();
         auto right_hierarchy = right->get_hierarchy();
 
-        auto transformer = [](auto& node_) { return node_->get_display_index().value_or(0); };
+        auto transformer = [](auto& node) { return node->get_display_index().value_or(0); };
         auto left_indices = left_hierarchy | ranges::views::transform(transformer);
         auto right_indices = right_hierarchy | ranges::views::transform(transformer);
 

--- a/foo_uie_albumlist/node_utils.h
+++ b/foo_uie_albumlist/node_utils.h
@@ -9,8 +9,8 @@ public:
         if (nodes.size() == 1) {
             m_tracks_ref = nodes[0]->get_sorted_tracks();
         } else {
-            for (auto& node_ : nodes) {
-                m_tracks.add_items(node_->get_sorted_tracks());
+            for (auto& node : nodes) {
+                m_tracks.add_items(node->get_sorted_tracks());
             }
         }
     }

--- a/foo_uie_albumlist/playlist_utils.cpp
+++ b/foo_uie_albumlist/playlist_utils.cpp
@@ -5,7 +5,7 @@ namespace alp {
 
 namespace {
 
-class titleformat_hook_view : public titleformat_hook {
+class TitleformatHookView : public titleformat_hook {
 public:
     bool process_field(
         titleformat_text_out* p_out, const char* p_name, size_t p_name_length, bool& p_found_flag) override
@@ -28,7 +28,7 @@ public:
         return false;
     }
 
-    explicit titleformat_hook_view(const char* p_view) : m_view{p_view} {}
+    explicit TitleformatHookView(const char* p_view) : m_view{p_view} {}
 
 private:
     const char* m_view;
@@ -66,7 +66,7 @@ void send_nodes_to_playlist(const std::vector<node_ptr>& nodes, bool replace_con
 
     if (create_new) {
         auto node_names
-            = nodes | ranges::views::transform([](auto& node_) { return node_->get_name(); }) | ranges::views::take(3);
+            = nodes | ranges::views::transform([](auto& node) { return node->get_name(); }) | ranges::views::take(3);
         auto playlist_name = mmh::join<decltype(node_names)&, std::string_view, std::string>(node_names, ", ");
 
         if (nodes.size() > 3)
@@ -97,7 +97,7 @@ void send_nodes_to_autosend_playlist(const std::vector<node_ptr>& nodes, const c
     const auto api = playlist_manager::get();
     pfc::string8 playlist_name;
 
-    titleformat_hook_view tf_hook{view};
+    TitleformatHookView tf_hook{view};
     titleformat_compiler::get()->run(&tf_hook, playlist_name, cfg_autosend_playlist_name);
     const auto index = api->find_or_create_playlist(playlist_name, pfc_infinite);
 

--- a/foo_uie_albumlist/prefs.cpp
+++ b/foo_uie_albumlist/prefs.cpp
@@ -54,18 +54,18 @@ static bool run_edit_view(edit_view_param& param, HWND parent)
 
 cfg_int cfg_child(GUID{0x637c25b6, 0x9166, 0xd8df, 0xae, 0x7a, 0x39, 0x75, 0x78, 0x08, 0xfa, 0xf0}, 0);
 
-tab_general g_config_general;
+TabGeneral g_config_general;
 
-tab_advanced g_config_advanced;
+TabAdvanced g_config_advanced;
 
-static preferences_tab* g_tabs[] = {
+static PreferencesTab* g_tabs[] = {
     &g_config_general,
     &g_config_advanced,
 };
 
-static preferences_page_factory_t<albumlist_prefs> foo3;
+static preferences_page_factory_t<PreferencesPage> foo3;
 
-void tab_general::refresh_views()
+void TabGeneral::refresh_views()
 {
     {
         HWND list = uGetDlgItem(m_wnd, IDC_VIEWS);
@@ -79,7 +79,7 @@ void tab_general::refresh_views()
     }
 }
 
-INT_PTR tab_general::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+INT_PTR TabGeneral::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_INITDIALOG: {
@@ -151,7 +151,7 @@ INT_PTR tab_general::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                         SendMessage(list, LB_DELETESTRING, idx, 0);
                         uSendMessageText(list, LB_INSERTSTRING, idx, temp);
                         uSendMessageText(list, LB_SETCURSEL, idx, nullptr);
-                        album_list_window::s_on_view_script_change(pbefore.name, p.name);
+                        AlbumListWindow::s_on_view_script_change(pbefore.name, p.name);
                     }
                 }
             }
@@ -226,7 +226,7 @@ INT_PTR tab_general::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 
 namespace {
 
-class font_client_album_list : public cui::fonts::client {
+class FontClient : public cui::fonts::client {
 public:
     const GUID& get_client_guid() const override { return album_list_font_client_id; }
 
@@ -234,12 +234,12 @@ public:
 
     cui::fonts::font_type_t get_default_font_type() const override { return cui::fonts::font_type_items; }
 
-    void on_font_changed() const override { album_list_window::s_update_all_fonts(); }
+    void on_font_changed() const override { AlbumListWindow::s_update_all_fonts(); }
 };
 
-font_client_album_list::factory<font_client_album_list> g_font_client_album_list;
+FontClient::factory<FontClient> g_font_client_album_list;
 
-class items_colours_client : public cui::colours::client {
+class ItemsColoursClient : public cui::colours::client {
 public:
     const GUID& get_client_guid() const override { return album_list_items_colours_client_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Album List: Items"; }
@@ -257,17 +257,17 @@ public:
     uint32_t get_supported_bools() const override { return cui::colours::bool_flag_dark_mode_enabled; }
     bool get_themes_supported() const override { return true; }
 
-    void on_colour_changed(uint32_t mask) const override { album_list_window::s_update_all_tree_colours(); }
+    void on_colour_changed(uint32_t mask) const override { AlbumListWindow::s_update_all_tree_colours(); }
     void on_bool_changed(uint32_t mask) const override
     {
         if (mask & cui::colours::bool_flag_dark_mode_enabled)
-            album_list_window::s_update_all_tree_themes();
+            AlbumListWindow::s_update_all_tree_themes();
     }
 };
 
-cui::colours::client::factory<items_colours_client> g_items_colours_client;
+cui::colours::client::factory<ItemsColoursClient> g_items_colours_client;
 
-class filter_colours_client : public cui::colours::client {
+class FilterColoursClient : public cui::colours::client {
 public:
     const GUID& get_client_guid() const override { return album_list_filter_colours_client_id; }
     void get_name(pfc::string_base& p_out) const override { p_out = "Album List: Filter"; }
@@ -278,19 +278,19 @@ public:
     uint32_t get_supported_bools() const override { return cui::colours::bool_flag_dark_mode_enabled; }
     bool get_themes_supported() const override { return false; }
 
-    void on_colour_changed(uint32_t mask) const override { album_list_window::s_update_all_edit_colours(); }
+    void on_colour_changed(uint32_t mask) const override { AlbumListWindow::s_update_all_edit_colours(); }
     void on_bool_changed(uint32_t mask) const override
     {
         if (mask & cui::colours::bool_flag_dark_mode_enabled)
-            album_list_window::s_update_all_edit_themes();
+            AlbumListWindow::s_update_all_edit_themes();
     }
 };
 
-cui::colours::client::factory<filter_colours_client> g_filter_colours_client;
+cui::colours::client::factory<FilterColoursClient> g_filter_colours_client;
 
 }; // namespace
 
-INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+INT_PTR TabAdvanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_INITDIALOG: {
@@ -352,7 +352,7 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             break;
         case IDC_ADD_ITEMS_USE_CORE_SORT:
             cfg_add_items_use_core_sort = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
-            album_list_window::s_mark_tracks_unsorted();
+            AlbumListWindow::s_mark_tracks_unsorted();
             break;
         case IDC_ADD_ITEMS_SELECT:
             cfg_add_items_select = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
@@ -362,18 +362,18 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             break;
         case IDC_SHOW_NUMBERS:
             cfg_show_subitem_counts = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
-            album_list_window::s_update_all_labels();
+            AlbumListWindow::s_update_all_labels();
             break;
         case IDC_AUTO_SEND:
             cfg_autosend = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
             break;
         case IDC_HSCROLL:
             cfg_show_horizontal_scroll_bar = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
-            album_list_window::s_update_all_showhscroll();
+            AlbumListWindow::s_update_all_showhscroll();
             break;
         case IDC_SHOW_ROOT:
             cfg_show_root_node = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
-            album_list_window::s_refresh_all();
+            AlbumListWindow::s_refresh_all();
             break;
         case IDC_AUTOPLAY:
             cfg_play_on_send = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
@@ -383,11 +383,11 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             break;
         case IDC_SHOW_NUMBERS2:
             cfg_show_item_indices = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
-            album_list_window::s_update_all_labels();
+            AlbumListWindow::s_update_all_labels();
             break;
         case (CBN_SELCHANGE << 16) | IDC_FRAME: {
             cfg_frame_style = ComboBox_GetCurSel(reinterpret_cast<HWND>(lp));
-            album_list_window::s_update_all_window_frames();
+            AlbumListWindow::s_update_all_window_frames();
         } break;
         case (EN_CHANGE << 16) | IDC_ITEM_HEIGHT: {
             if (m_initialised && cfg_use_custom_vertical_item_padding) {
@@ -399,7 +399,7 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     if (new_height < -99)
                         new_height = -99;
                     cfg_custom_vertical_padding_amount = new_height;
-                    album_list_window::s_update_all_item_heights();
+                    AlbumListWindow::s_update_all_item_heights();
                 }
             }
         } break;
@@ -415,7 +415,7 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             else
                 uSendMessageText(wnd_indent, WM_SETTEXT, 0, "");
 
-            album_list_window::s_update_all_item_heights();
+            AlbumListWindow::s_update_all_item_heights();
         } break;
         case IDC_USE_INDENT: {
             cfg_use_custom_indentation = Button_GetCheck(reinterpret_cast<HWND>(lp)) != BST_UNCHECKED;
@@ -428,7 +428,7 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
             else
                 uSendMessageText(wnd_indent, WM_SETTEXT, 0, "");
 
-            album_list_window::s_update_all_indents();
+            AlbumListWindow::s_update_all_indents();
         } break;
         case (EN_CHANGE << 16) | IDC_INDENT: {
             if (m_initialised && cfg_use_custom_indentation) {
@@ -438,7 +438,7 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
                     if (new_height > 999)
                         new_height = 999;
                     cfg_custom_indentation_amount = new_height;
-                    album_list_window::s_update_all_indents();
+                    AlbumListWindow::s_update_all_indents();
                 }
             }
         } break;
@@ -448,7 +448,7 @@ INT_PTR tab_advanced::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
     return 0;
 }
 
-void albumlist_prefs_instance::make_child(HWND wnd)
+void PreferencesPageInstance::make_child(HWND wnd)
 {
     if (m_child) {
         ShowWindow(m_child, SW_HIDE);
@@ -483,7 +483,7 @@ void albumlist_prefs_instance::make_child(HWND wnd)
     ShowWindow(m_child, SW_SHOWNORMAL);
 }
 
-INT_PTR albumlist_prefs_instance::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
+INT_PTR PreferencesPageInstance::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
 {
     switch (msg) {
     case WM_INITDIALOG: {

--- a/foo_uie_albumlist/prefs.h
+++ b/foo_uie_albumlist/prefs.h
@@ -1,12 +1,12 @@
 #pragma once
 
-class preferences_tab {
+class PreferencesTab {
 public:
     virtual HWND create(HWND wnd) = 0;
     virtual const char* get_name() = 0;
 };
 
-class tab_general : public preferences_tab {
+class TabGeneral : public PreferencesTab {
 public:
     bool is_active() { return m_wnd != nullptr; }
     void refresh_views();
@@ -26,7 +26,7 @@ private:
     HWND m_wnd{nullptr};
 };
 
-class tab_advanced : public preferences_tab {
+class TabAdvanced : public PreferencesTab {
 public:
     HWND create(HWND parent_window) override
     {
@@ -42,9 +42,9 @@ private:
     bool m_initialised{};
 };
 
-class albumlist_prefs_instance : public preferences_page_instance {
+class PreferencesPageInstance : public preferences_page_instance {
 public:
-    explicit albumlist_prefs_instance(HWND parent)
+    explicit PreferencesPageInstance(HWND parent)
     {
         const auto [_, has_dark_mode] = fbh::auto_dark_modeless_dialog_box(
             IDD_HOST, parent, [this](auto&&... args) { return on_message(std::forward<decltype(args)>(args)...); });
@@ -66,7 +66,7 @@ private:
     bool m_has_dark_mode{};
 };
 
-class albumlist_prefs : public preferences_page_v3 {
+class PreferencesPage : public preferences_page_v3 {
 public:
     const char* get_name() override { return "Album List Panel"; }
 
@@ -75,8 +75,8 @@ public:
     GUID get_parent_guid() override { return guid_media_library; }
     preferences_page_instance::ptr instantiate(fb2k::hwnd_t parent, preferences_page_callback::ptr callback) override
     {
-        return fb2k::service_new<albumlist_prefs_instance>(parent);
+        return fb2k::service_new<PreferencesPageInstance>(parent);
     }
 };
 
-extern tab_general g_config_general;
+extern TabGeneral g_config_general;

--- a/foo_uie_albumlist/tfhook.cpp
+++ b/foo_uie_albumlist/tfhook.cpp
@@ -1,6 +1,6 @@
 #include "stdafx.h"
 
-bool titleformat_hook_impl_file_info_branch::process_field(
+bool MetaBranchTitleformatHook::process_field(
     titleformat_text_out* p_out, const char* p_name, t_size p_name_length, bool& p_found_flag)
 {
     if (p_name_length > 2 && p_name[0] == '<') {
@@ -19,8 +19,8 @@ bool titleformat_hook_impl_file_info_branch::process_field(
     return baseClass::process_field(p_out, p_name, p_name_length, p_found_flag);
 }
 
-bool titleformat_hook_impl_file_info_branch::process_function(titleformat_text_out* p_out, const char* p_name,
-    t_size p_name_length, titleformat_hook_function_params* p_params, bool& p_found_flag)
+bool MetaBranchTitleformatHook::process_function(titleformat_text_out* p_out, const char* p_name, t_size p_name_length,
+    titleformat_hook_function_params* p_params, bool& p_found_flag)
 {
     bool strip = false, remapswap = false, remapstrip = false;
     if (!stricmp_utf8_ex(p_name, p_name_length, "meta_branch", pfc_infinite)) {
@@ -122,7 +122,7 @@ bool titleformat_hook_impl_file_info_branch::process_function(titleformat_text_o
     return baseClass::process_function(p_out, p_name, p_name_length, p_params, p_found_flag);
 }
 
-bool titleformat_hook_impl_file_info_branch::process_meta_branch(titleformat_text_out* p_out, t_size p_index)
+bool MetaBranchTitleformatHook::process_meta_branch(titleformat_text_out* p_out, t_size p_index)
 {
     if (p_index == pfc_infinite)
         return false;

--- a/foo_uie_albumlist/tfhook.h
+++ b/foo_uie_albumlist/tfhook.h
@@ -1,9 +1,9 @@
 #pragma once
 
-class titleformat_hook_impl_file_info_branch : public titleformat_hook_impl_file_info {
+class MetaBranchTitleformatHook : public titleformat_hook_impl_file_info {
 public:
     typedef titleformat_hook_impl_file_info baseClass;
-    titleformat_hook_impl_file_info_branch(const playable_location& p_location, const file_info* p_info)
+    MetaBranchTitleformatHook(const playable_location& p_location, const file_info* p_info)
         : titleformat_hook_impl_file_info(p_location, p_info)
     {
     }


### PR DESCRIPTION
This renames classes so that they use UpperCamelCase (following the [conventions used in Columns UI](https://github.com/reupen/columns_ui/blob/main/CONTRIBUTING.md#naming-conventions)).