### PR TITLE
Preserve filter query between sessions

### DIFF
--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -70,7 +70,7 @@ public:
     void on_size(unsigned cx, unsigned cy);
     void on_size();
 
-    void refresh_tree();
+    void refresh_tree(bool preserve_state = false);
     void update_tree(metadb_handle_list_t<pfc::alloc_fast_aggressive>& to_add,
         metadb_handle_list_t<pfc::alloc_fast_aggressive>& to_remove, bool preserve_existing);
     void build_nodes(metadb_handle_list_t<pfc::alloc_fast_aggressive>& tracks, bool preserve_existing = false);
@@ -157,6 +157,7 @@ private:
     std::optional<std::vector<node_ptr>> m_cleaned_selection;
     std::unordered_set<node_ptr> m_selection;
     std::optional<alp::SavedNodeState> m_node_state;
+    pfc::string m_saved_filter_query;
     search_filter::ptr m_filter_ptr;
     ui_selection_holder::ptr m_selection_holder;
     NodeFormatter m_node_formatter;

--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -564,7 +564,7 @@ void AlbumListWindow::update_tree(metadb_handle_list_t<pfc::alloc_fast_aggressiv
     restore_scroll_position();
 }
 
-void AlbumListWindow::refresh_tree()
+void AlbumListWindow::refresh_tree(bool preserve_state)
 {
     TRACK_CALL_TEXT("album_list_panel_refresh_tree");
 
@@ -574,13 +574,16 @@ void AlbumListWindow::refresh_tree()
     if (m_library_v4.is_valid() && !m_library_v4->is_initialized())
         return;
 
+    pfc::hires_timer timer;
+    timer.start();
+
+    if (preserve_state && m_root)
+        m_node_state = m_root->get_state(m_selection);
+
     metadb_handle_list_t<pfc::alloc_fast_aggressive> to_add;
     metadb_handle_list_t<pfc::alloc_fast_aggressive> to_remove;
     to_add.prealloc(1024);
     library_manager::get()->get_all_items(to_add);
-
-    pfc::hires_timer timer;
-    timer.start();
 
     update_tree(to_add, to_remove, false);
 

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -51,7 +51,7 @@ LRESULT AlbumListWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         break;
     case WM_TIMER:
         if (wp == EDIT_TIMER_ID) {
-            refresh_tree();
+            refresh_tree(true);
             KillTimer(wnd, wp);
             m_timer = false;
         }
@@ -98,15 +98,17 @@ LRESULT AlbumListWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_library_v3.reset();
 
         modeless_dialog_manager::g_remove(wnd);
-        if (m_root) {
+
+        if (m_root)
             m_node_state = m_root->get_state(m_selection);
-        }
+
         destroy_tree(true);
         destroy_filter();
         m_selection_holder.release();
         m_root.reset();
         m_selection.clear();
         m_cleaned_selection.reset();
+
         if (m_dd_theme) {
             CloseThemeData(m_dd_theme);
             m_dd_theme = nullptr;


### PR DESCRIPTION
Resolves #10

This saves and restores the entered filter query between foobar2000 sessions, or when simply closing and opening the filter.

It also preserves the selection if possible when updating the tree based on the entered filter query.