### PR TITLE
Improve Shift and Ctrl key handling

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -726,6 +726,18 @@ void AlbumListWindow::autosend()
         alp::send_nodes_to_autosend_playlist(get_cleaned_selection(), m_view, false);
 }
 
+void AlbumListWindow::update_shift_start_node()
+{
+    if ((GetKeyState(VK_SHIFT) & 0x8000) == 0) {
+        m_shift_start.reset();
+        return;
+    }
+
+    const auto caret = TreeView_GetSelection(m_wnd_tv);
+    const auto shift_start_item = caret ? caret : TreeView_GetRoot(m_wnd_tv);
+    m_shift_start = get_node_for_tree_item(shift_start_item);
+}
+
 void AlbumListWindow::update_selection_holder()
 {
     if (m_selection_holder.is_valid())

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -133,6 +133,7 @@ private:
     void select_range(const node_ptr& from, const node_ptr& to, bool expand) const;
     void autosend();
 
+    void update_shift_start_node();
     void update_selection_holder();
 
     const std::vector<node_ptr>& get_cleaned_selection();

--- a/foo_uie_albumlist/main_hook_proc.cpp
+++ b/foo_uie_albumlist/main_hook_proc.cpp
@@ -292,7 +292,7 @@ std::optional<LRESULT> AlbumListWindow::on_tree_lbuttondown(HWND wnd, UINT msg, 
             CallWindowProc(m_treeproc, wnd, msg, wp, lp);
         }
 
-        if (currently_selected && !manually_select_tree_item(tvhti.hItem, !currently_selected))
+        if (!manually_select_tree_item(tvhti.hItem, !currently_selected))
             return 0;
 
         autosend();

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -232,6 +232,8 @@ LRESULT AlbumListWindow::on_wm_contextmenu(POINT pt)
         = TrackPopupMenu(menu, TPM_RIGHTBUTTON | TPM_NONOTIFY | TPM_RETURNCMD, pt.x, pt.y, 0, get_wnd(), nullptr);
     DestroyMenu(menu);
 
+    update_shift_start_node();
+
     if (cmd > 0) {
         if (p_menu_manager.is_valid() && cmd >= IDM_MANAGER_BASE) {
             p_menu_manager->execute_by_id(cmd - IDM_MANAGER_BASE);


### PR DESCRIPTION
Resolves #29

This improves detection of Shift presses to cover some atypical cases (such as pressing it while the context menu is open), and fixes a bug where Ctrl- and Shift-clicking on items did not focus the tree view.

It also fixes a bug which caused Ctrl-clicking a focused, unselected item to do nothing.
