### PR TITLE
Fix handling of tracks being modified on foobar2000 2.0 and newer

### DIFF
--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -503,7 +503,7 @@ void AlbumListWindow::on_items_modified(const pfc::list_base_const_t<metadb_hand
 
 void AlbumListWindow::on_items_modified_v2(metadb_handle_list_cref items, metadb_io_callback_v2_data& data)
 {
-    if (m_library_v4->is_initialized())
+    if (!m_library_v4->is_initialized())
         return;
 
     on_items_modified(items);


### PR DESCRIPTION
A regression in 3c4f2d52b0abcb1fc2633ccee1423c58291d69c7 caused the modifications to tracks in the media library to not be handled on foobar2000 2.0 and newer.