### PR TITLE
Fix inability to drag multiple items

### DIFF
--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -118,6 +118,7 @@ private:
 
     LRESULT WINAPI on_tree_hooked_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
     std::optional<LRESULT> on_tree_lbuttondown(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
+    std::optional<LRESULT> on_tree_lbuttonup(HWND wnd, UINT msg, WPARAM wp, LPARAM lp);
 
     static inline pfc::ptr_list_t<AlbumListWindow> s_instances;
     static const GUID s_extension_guid;
@@ -148,6 +149,7 @@ private:
     bool m_populated{false};
     bool m_dragging{false};
     bool m_clicked{false};
+    std::weak_ptr<Node> m_delayed_click_node;
     bool m_filter{false};
     bool m_timer{false};
     bool m_process_char{true};

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -108,6 +108,7 @@ LRESULT AlbumListWindow::on_message(HWND wnd, UINT msg, WPARAM wp, LPARAM lp)
         m_root.reset();
         m_selection.clear();
         m_cleaned_selection.reset();
+        m_delayed_click_node.reset();
 
         if (m_dd_theme) {
             CloseThemeData(m_dd_theme);


### PR DESCRIPTION
Resolves #181

This resolves a problem where, when multiple items were selected, trying to drag them would only drag the item that was clicked on.

There were various changes that had to be made to click handling to accommodate this, so that the items are (correctly) deselected on mouse up rather than mouse down (when they aren't dragged).