### PR TITLE
Fix inconsistencies in middle-click behaviour

### DIFF
--- a/foo_uie_albumlist/main_hook_proc.cpp
+++ b/foo_uie_albumlist/main_hook_proc.cpp
@@ -215,13 +215,20 @@ LRESULT WINAPI AlbumListWindow::on_tree_hooked_message(HWND wnd, UINT msg, WPARA
         ti.pt.y = GET_Y_LPARAM(lp);
         TreeView_HitTest(wnd, &ti);
 
-        if (ti.flags & TVHT_ONITEM && ti.hItem) {
-            if (cfg_middle_click_action) {
-                TreeView_SelectItem(wnd, ti.hItem);
+        if (!(ti.flags & TVHT_ONITEM && ti.hItem && cfg_middle_click_action))
+            break;
 
-                do_click_action(static_cast<ClickAction>(cfg_middle_click_action.get_value()));
-            }
+        if (TreeView_GetSelection(wnd) != ti.hItem) {
+            TreeView_SelectItem(wnd, ti.hItem);
+        } else {
+            const auto node = get_node_for_tree_item(ti.hItem);
+            deselect_selected_nodes(node);
+
+            if (!m_selection.contains(node))
+                manually_select_tree_item(ti.hItem, true);
         }
+
+        do_click_action(static_cast<ClickAction>(cfg_middle_click_action.get_value()));
         break;
     }
     case WM_LBUTTONDBLCLK: {


### PR DESCRIPTION
This resolves some inconsistencies when middle-clicking on the focused item.

Previously, when middle-clicking on a non-focused item, it selected that item and deselected others. However, when middle-clicking on the focused item, it did not make any changes to the selection. This meant it did not select the item if it wasn't selected, nor did it deselect items other than the focused one that were selected.

Whether middle-clicking on a selected item instead preserve the selection remains an open question. This, however, makes the current behaviour consistent.