### PR TITLE
Make linker use /DEBUG:FULL and turn off /MAP

### DIFF
--- a/foo_uie_albumlist/foo_uie_albumlist.vcxproj
+++ b/foo_uie_albumlist/foo_uie_albumlist.vcxproj
@@ -128,8 +128,6 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>Usp10.lib;comctl32.lib;shell32.lib;shlwapi.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;Msimg32.lib;uxtheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <GenerateMapFile>true</GenerateMapFile>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention />
@@ -176,8 +174,6 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>Usp10.lib;comctl32.lib;shell32.lib;shlwapi.lib;gdiplus.lib;../foobar2000/shared/shared-$(Platform).lib;Msimg32.lib;uxtheme.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <GenerateMapFile>true</GenerateMapFile>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <DataExecutionPrevention>


### PR DESCRIPTION
/DEBUG:FASTLINK is no longer recommended, and it also isn't correct correct for PDBs that are published.