### PR TITLE
Fix compilation with VS 2022 17.8

### DIFF
--- a/foo_uie_albumlist/stdafx.h
+++ b/foo_uie_albumlist/stdafx.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #define OEMRESOURCE
 #define NOMINMAX
+#define _SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING
 
 #include <gsl/gsl>
 #include <fmt/format.h>


### PR DESCRIPTION
This applies the same workaround as https://github.com/reupen/columns_ui/pull/826 for the STL4043 warning.