### PR TITLE
Fix 32- and 64-bit configuration compatibility

### DIFF
--- a/foo_uie_albumlist/config.h
+++ b/foo_uie_albumlist/config.h
@@ -2,6 +2,13 @@
 
 class CfgViewList : public cfg_var {
 public:
+    CfgViewList& operator=(const CfgViewList& source)
+    {
+        m_data = source.m_data;
+        m_has_set_values = true;
+        return *this;
+    }
+
     void get_data_raw(stream_writer* out, abort_callback& p_abort) override;
     void set_data_raw(stream_reader* r, size_t psize, abort_callback& p_abort) override;
 
@@ -48,7 +55,12 @@ public:
 
     void swap(size_t index1, size_t index2) { m_data.swap_items(index1, index2); }
 
-    CfgViewList(const GUID& p_guid) : cfg_var(p_guid) { reset(); }
+    CfgViewList(const GUID& p_guid, bool read_and_write_legacy_size_value)
+        : cfg_var(p_guid)
+        , m_read_and_write_legacy_size_value(read_and_write_legacy_size_value)
+    {
+        reset();
+    }
 
     void format_display(size_t index, pfc::string_base& out) const
     {
@@ -57,6 +69,8 @@ public:
         out += get_value(index);
     }
 
+    bool has_read_values() const { return m_has_set_values; }
+
 private:
     struct entry {
         pfc::string8 name;
@@ -64,6 +78,8 @@ private:
     };
 
     pfc::list_t<entry> m_data;
+    bool m_read_and_write_legacy_size_value{};
+    bool m_has_set_values{};
 };
 
 constexpr GUID album_list_font_client_id{0x6b856cc, 0x86e7, 0x4459, 0xa7, 0x5c, 0x2d, 0xab, 0x5b, 0x33, 0xb8, 0xbb};
@@ -74,7 +90,6 @@ constexpr GUID album_list_filter_colours_client_id{
 constexpr GUID album_list_panel_preferences_page_id{
     0x53c89e50, 0x685d, 0x8ed1, 0x43, 0x25, 0x6b, 0xe8, 0x0f, 0x1b, 0xe7, 0x1f};
 
-extern CfgViewList cfg_views;
 extern cfg_bool cfg_themed;
 extern cfg_int cfg_populate_on_init;
 extern cfg_int cfg_autosend;
@@ -95,3 +110,5 @@ extern fbh::ConfigInt32DpiAware cfg_custom_indentation_amount;
 extern fbh::ConfigInt32DpiAware cfg_custom_vertical_padding_amount;
 extern cfg_int cfg_use_custom_vertical_item_padding;
 extern cfg_string cfg_autosend_playlist_name;
+
+CfgViewList& get_views();

--- a/foo_uie_albumlist/fcl.cpp
+++ b/foo_uie_albumlist/fcl.cpp
@@ -21,15 +21,17 @@ public:
     void get_data(stream_writer* writer, t_uint32 type, cui::fcl::t_export_feedback& feedback,
         abort_callback& p_abort) const override
     {
+        const auto& views = get_views();
+
         fbh::fcl::Writer w(writer, p_abort);
         w.write_raw(static_cast<uint32_t>(stream_version));
-        const uint32_t count = pfc::downcast_guarded<uint32_t>(cfg_views.get_count());
+        const uint32_t count = pfc::downcast_guarded<uint32_t>(views.get_count());
         w.write_raw(count);
 
         for (uint32_t i{0}; i < count; i++) {
             w.write_raw(uint32_t{2});
-            w.write_item(view_name, cfg_views.get_name(i));
-            w.write_item(view_script, cfg_views.get_value(i));
+            w.write_item(view_name, views.get_name(i));
+            w.write_item(view_script, views.get_value(i));
         }
     }
 
@@ -40,7 +42,7 @@ public:
         const auto version = fcl_reader.read_raw_item<uint32_t>();
 
         if (version <= stream_version) {
-            cfg_views.remove_all();
+            get_views().remove_all();
             const auto count = fcl_reader.read_raw_item<uint32_t>();
 
             for (uint32_t i{0}; i < count; i++)
@@ -63,6 +65,8 @@ private:
 
     static void read_item(fbh::fcl::Reader& fcl_reader)
     {
+        auto& views = get_views();
+
         auto elems = fcl_reader.read_raw_item<uint32_t>();
 
         pfc::string8 name;
@@ -85,7 +89,7 @@ private:
             }
             --elems;
         }
-        cfg_views.add_item(name, script);
+        views.add_item(name, script);
     }
 };
 

--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -196,9 +196,11 @@ bool AlbumListWindow::is_bydir() const
 
 const char* AlbumListWindow::get_hierarchy() const
 {
-    const auto index = cfg_views.find_item(m_view);
+    auto& views = get_views();
+
+    const auto index = views.find_item(m_view);
     if (index != pfc_infinite)
-        return cfg_views.get_value(index);
+        return views.get_value(index);
     return "N/A";
 }
 

--- a/foo_uie_albumlist/main_window_proc.cpp
+++ b/foo_uie_albumlist/main_window_proc.cpp
@@ -166,8 +166,10 @@ LRESULT AlbumListWindow::on_wm_contextmenu(POINT pt)
         }
     }
 
+    const auto& views = get_views();
+
     HMENU menu_view = CreatePopupMenu();
-    const size_t view_count = cfg_views.get_count();
+    const size_t view_count = views.get_count();
 
     uAppendMenu(menu_view, MF_STRING | (!stricmp_utf8(directory_structure_view_name, m_view) ? MF_CHECKED : 0),
         ID_VIEW_BASE + 0, directory_structure_view_name);
@@ -176,7 +178,7 @@ LRESULT AlbumListWindow::on_wm_contextmenu(POINT pt)
     view_names.emplace_back(directory_structure_view_name);
 
     for (size_t i = 0; i < view_count; i++) {
-        auto view_name = cfg_views.get_name(i);
+        auto view_name = views.get_name(i);
         view_names.emplace_back(view_name);
         uAppendMenu(menu_view, MF_STRING | (!stricmp_utf8(view_name, m_view) ? MF_CHECKED : 0), ID_VIEW_BASE + i + 1,
             view_name);

--- a/foo_uie_albumlist/menu.h
+++ b/foo_uie_albumlist/menu.h
@@ -18,11 +18,13 @@ public:
 
     MenuNodeSelectView(AlbumListWindow* p_wnd) : m_window{p_wnd}
     {
-        const auto view_count = cfg_views.get_count();
+        const auto& views = get_views();
+
+        const auto view_count = views.get_count();
         add_item(directory_structure_view_name);
 
         for (size_t i = 0; i < view_count; i++) {
-            add_item(cfg_views.get_name(i));
+            add_item(views.get_name(i));
         }
     }
 


### PR DESCRIPTION
This resolves a problem where the saved list of views wouldn't be read correctly by a 32-bit build of foobar2000 if foo_uie_albumlist.dll.cfg was written by a 64 build of foobar2000, and vice versa.

This was due to a `size_t` being incorrectly written in the serialised configuration.

On upgrade, the configuration is migrates to a new variable with a configuration format that is compatible between 32- and 64-bit versions of foobar2000. The old configuration value is also maintained to avoid data loss when downgrading to an older version of Album list panel.