### PR TITLE
Fix behaviour when Shift-selecting after media library additions

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -216,7 +216,6 @@ void AlbumListWindow::on_view_script_change(const char* p_view_before, const cha
 void AlbumListWindow::update_all_labels() const
 {
     if (m_root) {
-        m_root->mark_all_labels_dirty();
         SendMessage(m_wnd_tv, WM_SETREDRAW, FALSE, 0);
         TreeViewPopulator::s_setup_tree(m_wnd_tv, TVI_ROOT, m_root, std::nullopt, 0, 0);
         SendMessage(m_wnd_tv, WM_SETREDRAW, TRUE, 0);

--- a/foo_uie_albumlist/main_tree_builder.cpp
+++ b/foo_uie_albumlist/main_tree_builder.cpp
@@ -161,8 +161,9 @@ static void process_level_recur_t(
 {
     p_parent->set_bydir(t_entry::is_bydir);
     p_parent->set_data(ProcessEntryListWrapper<t_entry>(p_items, p_items_count), !b_add_only);
-    p_parent->m_label_dirty = cfg_show_subitem_counts != 0;
+
     assert(p_items_count > 0);
+
     pfc::array_t<t_local_entry> items_local;
     items_local.set_size(p_items_count);
     size_t items_local_ptr{0};
@@ -201,12 +202,6 @@ static void process_level_recur_t(
         process_level_recur_t<>(items_local.get_ptr(), items_local_ptr, p_node, b_add_only);
         items_local_ptr = 0;
         last_path = nullptr;
-    }
-
-    if (b_node_added && cfg_show_item_indices) {
-        size_t count = p_parent->get_children().size();
-        for (size_t i{0}; i < count; i++)
-            p_parent->get_children()[i]->m_label_dirty = true;
     }
 }
 

--- a/foo_uie_albumlist/node.cpp
+++ b/foo_uie_albumlist/node.cpp
@@ -140,11 +140,6 @@ node_ptr Node::add_child_v2(const char* p_value, size_t p_value_len)
     return temp;
 }
 
-void Node::mark_all_labels_dirty()
-{
-    apply_function([](auto& node) { node.m_label_dirty = true; });
-}
-
 void Node::mark_tracks_unsorted()
 {
     apply_function([](auto& node) { node.m_sorted = false; });
@@ -152,15 +147,8 @@ void Node::mark_tracks_unsorted()
 
 void Node::purge_empty_children(HWND wnd)
 {
-    size_t index_first_removed = pfc_infinite;
-
-    bool was_something_removed{};
     for (auto iter = m_children.begin(); iter != m_children.end();) {
         auto& child = *iter;
-
-        if (was_something_removed && cfg_show_item_indices) {
-            child->m_label_dirty = true;
-        }
 
         if (child->get_tracks().get_count()) {
             ++iter;
@@ -176,10 +164,5 @@ void Node::purge_empty_children(HWND wnd)
             TreeView_DeleteItem(wnd, child->m_ti);
 
         iter = m_children.erase(iter);
-
-        was_something_removed = true;
-
-        if (cfg_show_subitem_counts)
-            m_label_dirty = true;
     }
 }

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -7,7 +7,6 @@ typedef std::shared_ptr<class Node> node_ptr;
 class Node : public std::enable_shared_from_this<Node> {
 public:
     HTREEITEM m_ti{};
-    bool m_label_dirty{};
     bool m_children_inserted{};
     uint16_t m_level;
 
@@ -62,7 +61,6 @@ public:
 
     node_ptr add_child_v2(const char* p_value) { return add_child_v2(p_value, strlen(p_value)); }
 
-    void mark_all_labels_dirty();
     void mark_tracks_unsorted();
 
     void purge_empty_children(HWND wnd);


### PR DESCRIPTION
Resolves #257

This resolves a problem where, when item indices aren't shown, the wrong items were sometimes selected when using Shift-selecting after items were added to the media library while the panel was open.