### PR TITLE
Fix writing of bad config data when node state is missing

### DIFF
--- a/foo_uie_albumlist/node_state.cpp
+++ b/foo_uie_albumlist/node_state.cpp
@@ -38,9 +38,10 @@ void write_node_state(stream_writer* writer, const SavedNodeState& state, abort_
     writer->write(temp_writer.m_data.get_ptr(), temp_writer.m_data.get_size(), aborter);
 }
 
-auto read_node_state(stream_reader* reader, abort_callback& aborter) -> SavedNodeState
+auto read_node_state(stream_reader* reader, abort_callback& aborter, std::optional<uint32_t> read_size)
+    -> SavedNodeState
 {
-    const auto size = reader->read_lendian_t<uint32_t>(aborter);
+    const auto size = read_size ? *read_size : reader->read_lendian_t<uint32_t>(aborter);
 
     stream_reader_limited_ref limited_reader(reader, size);
 

--- a/foo_uie_albumlist/node_state.h
+++ b/foo_uie_albumlist/node_state.h
@@ -11,6 +11,7 @@ struct SavedNodeState {
 
 auto find_node_state(const std::vector<SavedNodeState>& items, const char* child_name) -> std::optional<SavedNodeState>;
 void write_node_state(stream_writer* writer, const SavedNodeState& state, abort_callback& aborter);
-auto read_node_state(stream_reader* reader, abort_callback& aborter) -> SavedNodeState;
+auto read_node_state(stream_reader* reader, abort_callback& aborter, std::optional<uint32_t> read_size = {})
+    -> SavedNodeState;
 
 } // namespace alp


### PR DESCRIPTION
This fixes a problem where bad configuration data was written when the node state was missing (for example, after doing a search with no results).

In some cases, this resulted in a crash when the panel was next initialised with that bad saved configuration data.

The configuration reading code was also updated to correctly handle the case where bad data had been previously saved.