### PR TITLE
Don't focus filter on window creation

### DIFF
--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -319,13 +319,13 @@ void AlbumListWindow::on_task_completion(t_uint32 task, t_uint32 code)
 void AlbumListWindow::create_or_destroy_filter()
 {
     if (m_filter)
-        create_filter();
+        create_filter(true);
     else
         destroy_filter();
     on_size();
 }
 
-void AlbumListWindow::create_filter()
+void AlbumListWindow::create_filter(bool set_focus)
 {
     if (m_filter && !m_wnd_edit) {
         const auto flags = WS_EX_CLIENTEDGE;
@@ -334,7 +334,8 @@ void AlbumListWindow::create_filter()
             core_api::get_my_instance(), nullptr);
         update_edit_theme();
         uih::set_window_font(m_wnd_edit, s_font.get(), false);
-        SetFocus(m_wnd_edit);
+        if (set_focus)
+            SetFocus(m_wnd_edit);
         Edit_SetCueBannerText(m_wnd_edit, L"Search");
     }
 }

--- a/foo_uie_albumlist/main.h
+++ b/foo_uie_albumlist/main.h
@@ -59,7 +59,7 @@ public:
     void toggle_show_filter();
 
     void create_or_destroy_filter();
-    void create_filter();
+    void create_filter(bool set_focus = false);
     void destroy_filter();
     void create_tree();
     void destroy_tree(bool should_save_scroll_position);


### PR DESCRIPTION
The panel attempted to focus the filter edit box when the panel window was created. This was incorrect, and caused the main window to be momentarily activated if foobar2000 was opened hidden or minimised.

This change stops the filter edit box from being focused on window creation. (It's still focused when opening the filter via the context menu.)