### PR TITLE
Preserve vertical bars in metadata

### DIFF
--- a/foo_uie_albumlist/foo_uie_albumlist.vcxproj
+++ b/foo_uie_albumlist/foo_uie_albumlist.vcxproj
@@ -296,6 +296,7 @@
     <ClCompile Include=".\tfhook.cpp" />
     <ClCompile Include="node_state.cpp" />
     <ClCompile Include="tree_view_populator.cpp" />
+    <ClCompile Include="utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include=".\config.h" />
@@ -311,6 +312,7 @@
     <ClInclude Include="node_state.h" />
     <ClInclude Include="node_utils.h" />
     <ClInclude Include="tree_view_populator.h" />
+    <ClInclude Include="utils.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\columns_ui-sdk\columns_ui-sdk.vcxproj">

--- a/foo_uie_albumlist/node.h
+++ b/foo_uie_albumlist/node.h
@@ -10,8 +10,7 @@ public:
     bool m_children_inserted{};
     uint16_t m_level;
 
-    Node(const char* name, size_t name_length, class AlbumListWindow* window, uint16_t level,
-        std::weak_ptr<Node> parent = {});
+    Node(std::string name, class AlbumListWindow* window, uint16_t level, std::weak_ptr<Node> parent = {});
 
     void sort_children();
 
@@ -30,16 +29,21 @@ public:
         m_children.clear();
     }
 
-    const char* get_name() const { return m_name.is_empty() ? "All music" : m_name.get_ptr(); }
+    std::string_view get_name() const { return m_name; }
+    std::string_view get_display_name() const { return m_name.empty() ? "?"sv : m_name; }
     const wchar_t* get_name_utf16()
     {
-        if (m_name.is_empty())
-            return L"All music";
-
         if (m_name_utf16.is_empty())
-            m_name_utf16.convert(m_name.get_ptr(), m_name.get_length());
+            m_name_utf16.convert(m_name.data(), m_name.length());
 
         return m_name_utf16.get_ptr();
+    }
+    const wchar_t* get_display_name_utf16()
+    {
+        if (m_name.empty())
+            return L"?";
+
+        return get_name_utf16();
     }
 
     void add_entry(const metadb_handle_ptr& p_entry) { m_tracks.add_item(p_entry); }
@@ -55,11 +59,9 @@ public:
 
     std::tuple<std::vector<node_ptr>::const_iterator, std::vector<node_ptr>::const_iterator> find_child(
         std::string_view name) const;
-    node_ptr find_or_add_child(const char* p_value, size_t p_value_len, bool b_find, bool& b_new);
+    node_ptr find_or_add_child(std::string name, bool b_find, bool& b_new);
 
-    node_ptr add_child_v2(const char* p_value, size_t p_value_len);
-
-    node_ptr add_child_v2(const char* p_value) { return add_child_v2(p_value, strlen(p_value)); }
+    node_ptr add_child_v2(std::string name);
 
     void mark_tracks_unsorted();
 
@@ -95,12 +97,12 @@ private:
 
     std::weak_ptr<Node> m_parent;
     std::optional<size_t> m_display_index;
-    pfc::string_simple m_name;
+    std::string m_name;
     pfc::stringcvt::string_wide_from_utf8 m_name_utf16;
     std::vector<node_ptr> m_children;
     metadb_handle_list m_tracks;
-    bool m_sorted : 1 {};
-    bool m_bydir : 1 {};
-    bool m_expanded : 1 {};
+    bool m_sorted{};
+    bool m_bydir{};
+    bool m_expanded{};
     class AlbumListWindow* m_window{};
 };

--- a/foo_uie_albumlist/node_formatter.h
+++ b/foo_uie_albumlist/node_formatter.h
@@ -12,7 +12,7 @@ public:
         const auto item_index = node->get_display_index();
 
         if ((!cfg_show_item_indices || item_count == 0) && !cfg_show_subitem_counts)
-            return node->get_name_utf16();
+            return node->get_display_name_utf16();
 
         if (cfg_show_item_indices && item_index && parent) {
             uint32_t pad_digits = 0;
@@ -25,7 +25,7 @@ public:
             format_to(std::back_inserter(m_buffer), L"{:0{}}. ", *item_index + 1, pad_digits);
         }
 
-        format_to(std::back_inserter(m_buffer), L"{}", node->get_name_utf16());
+        format_to(std::back_inserter(m_buffer), L"{}", node->get_display_name_utf16());
 
         if (cfg_show_subitem_counts && node->get_num_children())
             format_to(std::back_inserter(m_buffer), L" ({})", node->get_num_children());

--- a/foo_uie_albumlist/node_state.h
+++ b/foo_uie_albumlist/node_state.h
@@ -3,13 +3,14 @@
 namespace alp {
 
 struct SavedNodeState {
-    pfc::string name;
+    std::string name;
     bool expanded{};
     bool selected{};
     std::vector<SavedNodeState> children;
 };
 
-auto find_node_state(const std::vector<SavedNodeState>& items, const char* child_name) -> std::optional<SavedNodeState>;
+auto find_node_state(const std::vector<SavedNodeState>& items, std::string_view child_name)
+    -> std::optional<SavedNodeState>;
 void write_node_state(stream_writer* writer, const SavedNodeState& state, abort_callback& aborter);
 auto read_node_state(stream_reader* reader, abort_callback& aborter, std::optional<uint32_t> read_size = {})
     -> SavedNodeState;

--- a/foo_uie_albumlist/playlist_utils.cpp
+++ b/foo_uie_albumlist/playlist_utils.cpp
@@ -65,8 +65,8 @@ void send_nodes_to_playlist(const std::vector<node_ptr>& nodes, bool replace_con
         return;
 
     if (create_new) {
-        auto node_names
-            = nodes | ranges::views::transform([](auto& node) { return node->get_name(); }) | ranges::views::take(3);
+        auto node_names = nodes | ranges::views::transform([](auto& node) { return node->get_display_name(); })
+            | ranges::views::take(3);
         auto playlist_name = mmh::join<decltype(node_names)&, std::string_view, std::string>(node_names, ", ");
 
         if (nodes.size() > 3)

--- a/foo_uie_albumlist/utils.cpp
+++ b/foo_uie_albumlist/utils.cpp
@@ -1,0 +1,28 @@
+#include "stdafx.h"
+
+#include "utils.h"
+
+namespace alp::utils {
+
+std::string replace_substring(std::string_view input, std::string_view search, std::string_view replacement)
+{
+    std::string result;
+    size_t fragment_start{};
+
+    while (true) {
+        const auto fragment_end = input.find(search, fragment_start);
+        if (fragment_end == std::string_view::npos) {
+            result.append(input.substr(fragment_start));
+            break;
+        }
+
+        result.append(input.substr(fragment_start, fragment_end - fragment_start));
+        result.append(replacement);
+
+        fragment_start = fragment_end + search.length();
+    }
+
+    return result;
+}
+
+} // namespace alp::utils

--- a/foo_uie_albumlist/utils.h
+++ b/foo_uie_albumlist/utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace alp::utils {
+
+std::string replace_substring(std::string_view input, std::string_view search, std::string_view replacement);
+
+}


### PR DESCRIPTION
Resolves #393 

Previously, vertical bars in metadata were replaced with underscores as they would otherwise create new hierarchy levels in the tree.

This tweaks things to attempt to preserve them. During title formatting, they are now replaced with U+EFA0, a code point in the Unicode private use area that would not normally appear in metadata. After title formatting and splitting by `|`, the U+EFA0 characters are replaced with `|` again.