### PR TITLE
Add ability to configure autoplaylist sorting and filtering

### DIFF
--- a/foo_uie_albumlist/albumlist.rc
+++ b/foo_uie_albumlist/albumlist.rc
@@ -134,6 +134,22 @@ BEGIN
     COMBOBOX        IDC_MIDDLE,7,244,150,90,CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
 END
 
+IDD_EDIT_AUTOPLAYLIST DIALOGEX 0, 0, 330, 149
+STYLE DS_SETFONT | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Edit autoplaylist – Album list panel"
+FONT 8, "Tahoma", 0, 0, 0x0
+BEGIN
+    CONTROL         "Keep playlist sorted and prevent manual reordering",IDC_FORCE_SORT,
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,9,7,196,10
+    LTEXT           "Sorting pattern",IDC_STATIC,9,24,64,8
+    EDITTEXT        IDC_SORTING_PATTERN,9,35,312,31,ES_MULTILINE | ES_WANTRETURN | WS_VSCROLL
+    CONTROL         "Reverse sort",IDC_REVERSE_SORT,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,9,75,65,10
+    LTEXT           "Filter query",IDC_STATIC,9,93,63,8
+    EDITTEXT        IDC_FILTER_QUERY,9,104,312,12,ES_AUTOHSCROLL
+    DEFPUSHBUTTON   "OK",IDOK,218,128,50,14
+    PUSHBUTTON      "Cancel",IDCANCEL,271,128,50,14
+END
+
 
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -181,6 +197,14 @@ BEGIN
         TOPMARGIN, 9
         BOTTOMMARGIN, 265
     END
+
+    IDD_EDIT_AUTOPLAYLIST, DIALOG
+    BEGIN
+        LEFTMARGIN, 9
+        RIGHTMARGIN, 321
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 142
+    END
 END
 #endif    // APSTUDIO_INVOKED
 
@@ -211,6 +235,11 @@ BEGIN
 END
 
 IDD_EDIT_VIEW AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+IDD_EDIT_AUTOPLAYLIST AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/foo_uie_albumlist/autoplaylist.cpp
+++ b/foo_uie_albumlist/autoplaylist.cpp
@@ -42,6 +42,9 @@ bool compare_part(std::string_view text, std::string_view expected)
 
 std::string get_autoplaylist_name(auto&& labels_by_node)
 {
+    if (labels_by_node.empty())
+        return "All music"s;
+
     auto leaf_labels = labels_by_node | ranges::views::take(2) | ranges::views::transform([](auto&& labels) {
         const auto leaf = labels.back();
 
@@ -57,17 +60,98 @@ std::string get_autoplaylist_name(auto&& labels_by_node)
     return mmh::join<const decltype(leaf_labels)&, std::string_view, std::string>(leaf_labels, ", "sv).c_str();
 }
 
+struct ConfigurationState {
+    size_t playlist_index{};
+    bool is_force_sorted{};
+    std::string sorting_pattern;
+    bool is_reverse_sort{};
+    std::string filter_query;
+    bool is_dirty{};
+};
+
+HWND show_configuration_dialog(
+    ConfigurationState state, std::function<void(const ConfigurationState&)> on_commit, std::function<void()> on_close)
+{
+    playlist_position_reference_tracker playlist_index_tracker(false);
+    playlist_index_tracker.m_playlist = state.playlist_index;
+
+    auto [wnd, _] = fbh::auto_dark_modeless_dialog_box(IDD_EDIT_AUTOPLAYLIST, core_api::get_main_window(),
+        [state{std::move(state)}, playlist_index_tracker{std::move(playlist_index_tracker)},
+            on_commit(std::move(on_commit)),
+            on_close{std::move(on_close)}](auto wnd, auto msg, auto wp, auto lp) mutable -> INT_PTR {
+            switch (msg) {
+            case WM_INITDIALOG: {
+                modeless_dialog_manager::g_add(wnd);
+                uih::enhance_edit_control(wnd, IDC_SORTING_PATTERN);
+                uih::enhance_edit_control(wnd, IDC_FILTER_QUERY);
+                Button_SetCheck(GetDlgItem(wnd, IDC_FORCE_SORT), state.is_force_sorted ? BST_CHECKED : BST_UNCHECKED);
+                SetWindowText(GetDlgItem(wnd, IDC_SORTING_PATTERN), mmh::to_utf16(state.sorting_pattern).c_str());
+                Button_SetCheck(GetDlgItem(wnd, IDC_REVERSE_SORT), state.is_reverse_sort ? BST_CHECKED : BST_UNCHECKED);
+                SetWindowText(GetDlgItem(wnd, IDC_FILTER_QUERY), mmh::to_utf16(state.filter_query).c_str());
+                return TRUE;
+            }
+            case WM_COMMAND:
+                switch (wp) {
+                case IDC_FORCE_SORT:
+                    state.is_force_sorted = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
+                    state.is_dirty = true;
+                    break;
+                case IDC_REVERSE_SORT:
+                    state.is_reverse_sort = Button_GetCheck(reinterpret_cast<HWND>(lp)) == BST_CHECKED;
+                    state.is_dirty = true;
+                    break;
+                case IDC_SORTING_PATTERN | EN_CHANGE << 16:
+                    if (IsWindowVisible(wnd)) {
+                        state.sorting_pattern = mmh::to_utf8(uih::get_window_text(reinterpret_cast<HWND>(lp)));
+                        state.is_dirty = true;
+                    }
+                    break;
+                case IDC_FILTER_QUERY | EN_CHANGE << 16:
+                    if (IsWindowVisible(wnd)) {
+                        state.filter_query = mmh::to_utf8(uih::get_window_text(reinterpret_cast<HWND>(lp)));
+                        state.is_dirty = true;
+                    }
+                    break;
+                case IDOK:
+                    if (state.is_dirty) {
+                        state.playlist_index = playlist_index_tracker.m_playlist;
+                        on_commit(state);
+                    }
+                    [[fallthrough]];
+                case IDCANCEL:
+                    DestroyWindow(wnd);
+                    return 0;
+                }
+                break;
+            case WM_CLOSE:
+                DestroyWindow(wnd);
+                return 0;
+            case WM_DESTROY:
+                on_close();
+                modeless_dialog_manager::g_remove(wnd);
+                break;
+            }
+
+            return FALSE;
+        });
+
+    ShowWindow(wnd, SW_SHOWNORMAL);
+    return wnd;
+}
+
 } // namespace
 
 class ByFormatAutoplaylistClient : public autoplaylist_client_v3 {
 public:
     ByFormatAutoplaylistClient(wil::zstring_view view_titleformat, std::vector<std::vector<std::string>> node_labels,
-        auto&& filter, std::string sort_titleformat)
+        auto&& filter, bool is_force_sorted, std::string sort_titleformat, bool is_reverse_sort)
         : m_view_titleformat(view_titleformat)
         , m_titleformat_object(titleformat_compiler::get()->compile(view_titleformat.c_str()))
         , m_labels_by_node(std::move(node_labels))
         , m_filter(std::forward<decltype(filter)>(filter))
+        , m_is_force_sorted(is_force_sorted)
         , m_sort_titleformat(std::move(sort_titleformat))
+        , m_is_reverse_sort(is_reverse_sort)
     {
     }
 
@@ -76,9 +160,11 @@ public:
     void get_configuration(stream_writer* p_stream, abort_callback& p_abort) override
     {
         p_stream->write_lendian_t(false, p_abort);
+
+        std::scoped_lock lock(m_mutex);
         p_stream->write_string(m_view_titleformat.c_str(), p_abort);
         p_stream->write_string(m_filter.c_str(), p_abort);
-        p_stream->write_lendian_t(false, p_abort);
+        p_stream->write_lendian_t(m_is_force_sorted, p_abort);
         p_stream->write_string(m_sort_titleformat.c_str(), p_abort);
         p_stream->write_lendian_t(gsl::narrow<uint32_t>(m_labels_by_node.size()), p_abort);
 
@@ -88,32 +174,88 @@ public:
             for (const auto& label : node_labels)
                 p_stream->write_string(label.c_str(), p_abort);
         }
+
+        p_stream->write_lendian_t(m_is_reverse_sort, p_abort);
     }
 
-    void show_ui(t_size p_source_playlist) override {}
-    void set_full_refresh_notify(completion_notify::ptr notify) override { m_completion_notify = notify; }
-    bool show_ui_available() override { return false; }
+    void show_ui(t_size p_source_playlist) override
+    {
+        if (m_configuration_dialog_wnd) {
+            SetForegroundWindow(m_configuration_dialog_wnd);
+            return;
+        }
+
+        std::unique_lock lock(m_mutex);
+        ConfigurationState state{p_source_playlist, m_is_force_sorted, m_sort_titleformat, m_is_reverse_sort, m_filter};
+        lock.unlock();
+
+        m_configuration_dialog_wnd = show_configuration_dialog(
+            std::move(state),
+            [this, self{ptr{this}}](auto& state) {
+                if (state.playlist_index == SIZE_MAX)
+                    return;
+
+                std::unique_lock lock(m_mutex);
+
+                const auto old_is_force_sorted = m_is_force_sorted;
+
+                m_is_force_sorted = state.is_force_sorted;
+                m_sort_titleformat = state.sorting_pattern;
+                m_is_reverse_sort = state.is_reverse_sort;
+                m_filter = state.filter_query;
+                const auto completion_notify = m_completion_notify;
+
+                lock.unlock();
+
+                if (old_is_force_sorted != state.is_force_sorted) {
+                    const auto manager_api = autoplaylist_manager_v2::get();
+                    manager_api->set_client_flags(this, state.is_force_sorted ? autoplaylist_flag_sort : 0);
+                }
+
+                if (completion_notify.is_valid())
+                    completion_notify->on_completion(1);
+            },
+            [this, self{ptr{this}}] { m_configuration_dialog_wnd = nullptr; });
+    }
+
+    void set_full_refresh_notify(completion_notify::ptr notify) override
+    {
+        std::scoped_lock _scoped_lock(m_mutex);
+        m_completion_notify = notify;
+    }
+    bool show_ui_available() override { return true; }
     void get_display_name(pfc::string_base& out) override { out = "Album list panel"; }
 
     bool supports_async() override { return true; }
     void filter_v2(metadb_handle_list_cref items, metadb_io_callback_v2_data* dataIfAvailable, bool* out,
         abort_callback& abort) override
     {
-        if (!m_filter.empty()) {
-            const auto filter_obj
-                = search_filter_manager_v2::get()->create_ex(m_filter.c_str(), m_completion_notify, 0);
+        const auto& labels_by_node = m_labels_by_node;
+
+        std::unique_lock lock(m_mutex);
+        const auto completion_notify = m_completion_notify;
+        const auto filter = m_filter;
+        const auto titleformat_obj = m_titleformat_object;
+        lock.unlock();
+
+        if (!filter.empty()) {
+            const auto filter_obj = search_filter_manager_v2::get()->create_ex(filter.c_str(), completion_notify,
+                completion_notify.is_valid() ? 0 : search_filter_manager_v2::KFlagSuppressNotify);
             filter_obj->test_multi_ex(items, out, abort);
         } else {
             std::fill_n(out, items.size(), true);
         }
+
+        if (labels_by_node.empty())
+            return;
 
         concurrency::combinable<std::string> format_buffer;
         concurrency::combinable<std::string> unescaped_segment_buffer;
         concurrency::combinable<std::vector<std::string_view>> segments_buffer;
 
         concurrency::parallel_for(size_t{}, items.size(),
-            [this, &items, &out, &dataIfAvailable, &format_buffer, &unescaped_segment_buffer, &segments_buffer](
-                size_t index) {
+            [&labels_by_node, &titleformat_obj, &items, &out, &dataIfAvailable, &format_buffer,
+                &unescaped_segment_buffer, &segments_buffer](size_t index) {
                 metadb_info_container::ptr info_ptr;
                 metadb_v2_rec_t rec;
 
@@ -139,8 +281,7 @@ public:
 
                 auto& formatted_title = format_buffer.local();
                 mmh::StringAdaptor interop_title(formatted_title);
-                items[index]->format_title(
-                    &tf_hook_file_info, interop_title, m_titleformat_object, &tf_hook_text_filter);
+                items[index]->format_title(&tf_hook_file_info, interop_title, titleformat_obj, &tf_hook_text_filter);
 
                 auto& segments = segments_buffer.local();
                 segments.clear();
@@ -152,7 +293,7 @@ public:
 
                 auto& unescaped_segment = unescaped_segment_buffer.local();
 
-                out[index] = ranges::any_of(m_labels_by_node, [&](auto&& labels) {
+                out[index] = ranges::any_of(labels_by_node, [&](auto&& labels) {
                     if (segments.size() < labels.size())
                         return false;
 
@@ -167,15 +308,21 @@ public:
 
     bool sort_v2(metadb_handle_list_cref p_items, t_size* p_orderbuffer, abort_callback& abort) override
     {
-        if (m_sort_titleformat.empty())
+        std::unique_lock lock(m_mutex);
+        const auto sort_titleformat = m_sort_titleformat;
+        const auto is_reverse_sort = m_is_reverse_sort;
+        lock.unlock();
+
+        if (sort_titleformat.empty())
             return false;
 
         service_ptr_t<titleformat_object> sort_script;
-        titleformat_compiler::get()->compile_safe_ex(sort_script, m_sort_titleformat.c_str());
+        titleformat_compiler::get()->compile_safe_ex(sort_script, sort_titleformat.c_str());
 
         std::span permutation(p_orderbuffer, p_items.size());
         mmh::fill_identity_permutation(permutation);
-        fbh::sort_metadb_handle_list_by_format_get_permutation(p_items, permutation, sort_script, nullptr);
+        fbh::sort_metadb_handle_list_by_format_get_permutation(
+            p_items, permutation, sort_script, nullptr, false, is_reverse_sort);
 
         return true;
     }
@@ -185,20 +332,26 @@ public:
     fb2k::arrayRef get_contents(abort_callback& a) override { return {}; }
 
 private:
+    std::mutex m_mutex;
     std::string m_view_titleformat;
     titleformat_object::ptr m_titleformat_object;
     std::vector<std::vector<std::string>> m_labels_by_node;
     std::string m_filter;
+    bool m_is_force_sorted{};
+    bool m_is_reverse_sort{};
     std::string m_sort_titleformat;
     completion_notify::ptr m_completion_notify;
+    HWND m_configuration_dialog_wnd{};
 };
 
 class ByDirAutoplaylistClient : public autoplaylist_client_v3 {
 public:
-    ByDirAutoplaylistClient(
-        std::vector<std::vector<std::string>> node_labels, auto&& filter, std::string sort_titleformat)
+    ByDirAutoplaylistClient(std::vector<std::vector<std::string>> node_labels, auto&& filter, bool is_force_sorted,
+        std::string sort_titleformat, bool is_reverse_sort)
         : m_labels_by_node(std::move(node_labels))
         , m_filter(std::forward<decltype(filter)>(filter))
+        , m_is_force_sorted(is_force_sorted)
+        , m_is_reverse_sort(is_reverse_sort)
         , m_sort_titleformat(std::move(sort_titleformat))
     {
     }
@@ -208,8 +361,10 @@ public:
     void get_configuration(stream_writer* p_stream, abort_callback& p_abort) override
     {
         p_stream->write_lendian_t(true, p_abort);
+
+        std::scoped_lock lock(m_mutex);
         p_stream->write_string(m_filter.c_str(), p_abort);
-        p_stream->write_lendian_t(false, p_abort);
+        p_stream->write_lendian_t(m_is_force_sorted, p_abort);
         p_stream->write_string(m_sort_titleformat.c_str(), p_abort);
         p_stream->write_lendian_t(gsl::narrow<uint32_t>(m_labels_by_node.size()), p_abort);
 
@@ -219,30 +374,84 @@ public:
             for (const auto& label : node_labels)
                 p_stream->write_string(label.c_str(), p_abort);
         }
+
+        p_stream->write_lendian_t(m_is_reverse_sort, p_abort);
     }
 
-    void show_ui(t_size p_source_playlist) override {}
-    void set_full_refresh_notify(completion_notify::ptr notify) override { m_completion_notify = notify; }
-    bool show_ui_available() override { return false; }
+    void show_ui(t_size p_source_playlist) override
+    {
+        if (m_configuration_dialog_wnd) {
+            SetForegroundWindow(m_configuration_dialog_wnd);
+            return;
+        }
+
+        std::unique_lock lock(m_mutex);
+        ConfigurationState state{p_source_playlist, m_is_force_sorted, m_sort_titleformat, m_is_reverse_sort, m_filter};
+        lock.unlock();
+
+        m_configuration_dialog_wnd = show_configuration_dialog(
+            std::move(state),
+            [this, self{ptr{this}}](auto& state) {
+                if (state.playlist_index == SIZE_MAX)
+                    return;
+
+                std::unique_lock lock(m_mutex);
+
+                const auto old_is_force_sorted = m_is_force_sorted;
+
+                m_is_force_sorted = state.is_force_sorted;
+                m_sort_titleformat = state.sorting_pattern;
+                m_is_reverse_sort = state.is_reverse_sort;
+                m_filter = state.filter_query;
+                const auto completion_notify = m_completion_notify;
+
+                lock.unlock();
+
+                if (old_is_force_sorted != state.is_force_sorted) {
+                    const auto manager_api = autoplaylist_manager_v2::get();
+                    manager_api->set_client_flags(this, state.is_force_sorted ? autoplaylist_flag_sort : 0);
+                }
+
+                if (completion_notify.is_valid())
+                    completion_notify->on_completion(1);
+            },
+            [this, self{ptr{this}}] { m_configuration_dialog_wnd = nullptr; });
+    }
+    void set_full_refresh_notify(completion_notify::ptr notify) override
+    {
+        std::scoped_lock _scoped_lock(m_mutex);
+        m_completion_notify = notify;
+    }
+    bool show_ui_available() override { return true; }
     void get_display_name(pfc::string_base& out) override { out = "Album list panel"; }
 
     bool supports_async() override { return true; }
     void filter_v2(metadb_handle_list_cref items, metadb_io_callback_v2_data* dataIfAvailable, bool* out,
         abort_callback& abort) override
     {
-        if (!m_filter.empty()) {
-            const auto filter_obj
-                = search_filter_manager_v2::get()->create_ex(m_filter.c_str(), m_completion_notify, 0);
+        const auto& labels_by_node = m_labels_by_node;
+
+        std::unique_lock lock(m_mutex);
+        const auto completion_notify = m_completion_notify;
+        const auto filter = m_filter;
+        lock.unlock();
+
+        if (!filter.empty()) {
+            const auto filter_obj = search_filter_manager_v2::get()->create_ex(filter.c_str(), completion_notify,
+                completion_notify.is_valid() ? 0 : search_filter_manager_v2::KFlagSuppressNotify);
             filter_obj->test_multi_ex(items, out, abort);
         } else {
             std::fill_n(out, items.size(), true);
         }
 
+        if (labels_by_node.empty())
+            return;
+
         const auto library_api = library_manager::get();
         concurrency::combinable<std::vector<std::string_view>> segments_buffer;
 
         concurrency::parallel_for(
-            size_t{}, items.size(), [this, &items, &out, &library_api, &segments_buffer](size_t index) {
+            size_t{}, items.size(), [&labels_by_node, &items, &out, &library_api, &segments_buffer](size_t index) {
                 metadb_info_container::ptr info_ptr;
                 metadb_v2_rec_t rec;
 
@@ -265,7 +474,7 @@ public:
 
                 ranges::copy(segments_view, std::back_inserter(segments));
 
-                out[index] = ranges::any_of(m_labels_by_node, [&](auto&& labels) {
+                out[index] = ranges::any_of(labels_by_node, [&](auto&& labels) {
                     if (segments.size() < labels.size())
                         return false;
 
@@ -280,15 +489,21 @@ public:
 
     bool sort_v2(metadb_handle_list_cref p_items, t_size* p_orderbuffer, abort_callback& abort) override
     {
-        if (m_sort_titleformat.empty())
+        std::unique_lock lock(m_mutex);
+        const auto sort_titleformat = m_sort_titleformat;
+        const auto is_reverse_sort = m_is_reverse_sort;
+        lock.unlock();
+
+        if (sort_titleformat.empty())
             return false;
 
         service_ptr_t<titleformat_object> sort_script;
-        titleformat_compiler::get()->compile_safe_ex(sort_script, "%path_sort%");
+        titleformat_compiler::get()->compile_safe_ex(sort_script, sort_titleformat.c_str());
 
         std::span permutation(p_orderbuffer, p_items.size());
         mmh::fill_identity_permutation(permutation);
-        fbh::sort_metadb_handle_list_by_format_get_permutation(p_items, permutation, sort_script, nullptr);
+        fbh::sort_metadb_handle_list_by_format_get_permutation(
+            p_items, permutation, sort_script, nullptr, false, is_reverse_sort);
 
         return true;
     }
@@ -298,10 +513,14 @@ public:
     fb2k::arrayRef get_contents(abort_callback& a) override { return {}; }
 
 private:
+    std::mutex m_mutex;
     std::vector<std::vector<std::string>> m_labels_by_node;
     std::string m_filter;
+    bool m_is_force_sorted{};
+    bool m_is_reverse_sort{};
     std::string m_sort_titleformat;
     completion_notify::ptr m_completion_notify;
+    HWND m_configuration_dialog_wnd{};
 };
 
 namespace {
@@ -315,7 +534,7 @@ public:
         const auto view_titleformat = is_by_dir ? pfc::string8() : p_stream->read_string(p_abort);
         const auto filter = p_stream->read_string(p_abort);
 
-        [[maybe_unused]] const auto is_force_sorted = p_stream->read_lendian_t<bool>(p_abort);
+        const auto is_force_sorted = p_stream->read_lendian_t<bool>(p_abort);
 
         std::string sort_titleformat;
         mmh::StringAdaptor adapted_sort_titleformat(sort_titleformat);
@@ -332,12 +551,19 @@ public:
                 label = p_stream->read_string(p_abort);
         }
 
-        if (is_by_dir)
-            return fb2k::service_new<ByDirAutoplaylistClient>(
-                std::move(labels_by_node), std::move(filter), std::move(sort_titleformat));
+        bool is_reverse_sort{};
 
-        return fb2k::service_new<ByFormatAutoplaylistClient>(
-            view_titleformat, std::move(labels_by_node), std::move(filter), std::move(sort_titleformat));
+        try {
+            is_reverse_sort = p_stream->read_lendian_t<bool>(p_abort);
+        } catch (const exception_io_data_truncation&) {
+        }
+
+        if (is_by_dir)
+            return fb2k::service_new<ByDirAutoplaylistClient>(std::move(labels_by_node), std::move(filter),
+                is_force_sorted, std::move(sort_titleformat), is_reverse_sort);
+
+        return fb2k::service_new<ByFormatAutoplaylistClient>(view_titleformat, std::move(labels_by_node),
+            std::move(filter), is_force_sorted, std::move(sort_titleformat), is_reverse_sort);
     }
 };
 
@@ -348,11 +574,6 @@ service_factory_t<AutoplaylistClientFactory> _autoplaylist_client_factory;
 void create_autoplaylist(bool is_by_dir, wil::zstring_view view_titleformat,
     std::vector<std::vector<wil::zstring_view>> node_labels, std::string_view filter)
 {
-    assert(!node_labels.empty());
-
-    if (node_labels.empty())
-        return;
-
     const auto playlist_name = get_autoplaylist_name(node_labels);
 
     const auto playlist_api = playlist_manager_v4::get();
@@ -372,9 +593,9 @@ void create_autoplaylist(bool is_by_dir, wil::zstring_view view_titleformat,
     }
 
     auto client = is_by_dir ? autoplaylist_client::ptr(fb2k::service_new<ByDirAutoplaylistClient>(
-                                  std::move(node_labels_strings), filter, std::move(sort_titleformat)))
+                                  std::move(node_labels_strings), filter, false, std::move(sort_titleformat), false))
                             : autoplaylist_client::ptr(fb2k::service_new<ByFormatAutoplaylistClient>(view_titleformat,
-                                  std::move(node_labels_strings), filter, std::move(sort_titleformat)));
+                                  std::move(node_labels_strings), filter, false, std::move(sort_titleformat), false));
 
     autoplaylist_api->add_client(std::move(client), playlist_index, 0);
 

--- a/foo_uie_albumlist/main.cpp
+++ b/foo_uie_albumlist/main.cpp
@@ -839,36 +839,17 @@ void AlbumListWindow::create_autoplaylist(const std::span<const node_ptr> nodes)
     if (m_wnd_edit)
         uGetWindowText(m_wnd_edit, filter);
 
-    if (ranges::contains(nodes, m_root)) {
-        const auto name = "All music"sv;
-        const auto playlist_api = playlist_manager_v4::get();
-        const auto playlist_index = playlist_api->create_playlist(name.data(), name.size(), SIZE_MAX);
+    const auto has_root = ranges::contains(nodes, m_root);
 
-        pfc::string8 sort_format;
-
-        if (!cfg_add_items_use_core_sort) {
-            if (is_by_dir)
-                sort_format = "%path_sort%";
-            else {
-                sort_format = get_hierarchy();
-                sort_format += "|%path_sort%";
-            }
-        }
-
-        autoplaylist_manager_v2::get()->add_client_simple(filter.empty() ? "ALL" : filter.c_str(),
-            sort_format.is_empty() ? nullptr : sort_format.c_str(), playlist_index, 0);
-        playlist_api->set_active_playlist(playlist_index);
-        return;
-    }
-
-    auto labels = nodes | ranges::views::transform([&](auto&& node) {
-        auto hierarchy = node->get_hierarchy();
-        return hierarchy | ranges::views::drop(1)
-            | ranges::views::transform([](const auto& node) { return node->get_name(); }) | ranges::to_vector;
-    });
+    auto labels
+        = has_root ? std::vector<std::vector<wil::zstring_view>>{} : nodes | ranges::views::transform([&](auto&& node) {
+              auto hierarchy = node->get_hierarchy();
+              return hierarchy | ranges::views::drop(1)
+                  | ranges::views::transform([](const auto& node) { return node->get_name(); }) | ranges::to_vector;
+          }) | ranges::to_vector;
 
     alp::create_autoplaylist(
-        is_by_dir, is_by_dir ? "" : get_hierarchy(), labels | ranges::to_vector, {filter.c_str(), filter.length()});
+        is_by_dir, is_by_dir ? "" : get_hierarchy(), std::move(labels), {filter.c_str(), filter.length()});
 }
 
 // {606E9CDD-45EE-4c3b-9FD5-49381CEBE8AE}

--- a/foo_uie_albumlist/resource.h
+++ b/foo_uie_albumlist/resource.h
@@ -7,6 +7,7 @@
 #define IDD_HOST                        191
 #define IDD_APPEARANCE_TAB              192
 #define IDD_BEHAVIOUR_TAB               193
+#define IDD_EDIT_AUTOPLAYLIST           194
 #define IDC_SHOW_COUNTS                 1005
 #define IDC_SHOW_INDICES                1006
 #define IDC_DBLCLK                      1007
@@ -37,6 +38,10 @@
 #define IDC_AUTOCOLLAPSE                1038
 #define IDC_TAB1                        1039
 #define IDC_ADD_ITEMS_USE_CORE_SORT     1041
+#define IDC_FORCE_SORT                  1041
+#define IDC_SORTING_PATTERN             1042
+#define IDC_FILTER_QUERY                1043
+#define IDC_REVERSE_SORT                1044
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -45,7 +50,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        108
 #define _APS_NEXT_COMMAND_VALUE         40004
-#define _APS_NEXT_CONTROL_VALUE         1041
+#define _APS_NEXT_CONTROL_VALUE         1045
 #define _APS_NEXT_SYMED_VALUE           103
 #endif
 #endif

--- a/foo_uie_albumlist/stdafx.h
+++ b/foo_uie_albumlist/stdafx.h
@@ -27,6 +27,7 @@
 #include "../columns_ui-sdk/ui_extension.h"
 
 #include "../foobar2000/SDK/foobar2000.h"
+#include "../foobar2000/helpers/playlist_position_reference_tracker.h"
 #include "resource.h"
 #include <commctrl.h>
 #include <windowsx.h>


### PR DESCRIPTION
This adds the ability to customise the sorting of and amend the filter used by an autoplaylist after it’s been created. This includes the ability to enable force-sorting of the autoplaylist and to reverse the sort order.

 The configuration dialogue can be accessed from the context menu of the playlist.

Additionally, autoplaylists that include the root node now also use the Album list panel autoplaylist client, so that they can be configured in the same way as autoplaylists that include sub-branches.