### PR TITLE
Update dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "album-list-panel",
   "version-string": "git",
-  "builtin-baseline": "74e6536215718009aae747d86d84b78376bf9e09",
+  "builtin-baseline": "927f62e4b8838bd7e441e9c45103a16ffd75007e",
   "dependencies": ["fmt", "foonathan-lexy", "ms-gsl", "range-v3", "wil"],
   "overrides": [
     {
@@ -14,7 +14,7 @@
     },
     {
       "name": "ms-gsl",
-      "version": "4.2.0"
+      "version": "4.2.2"
     },
     {
       "name": "range-v3",
@@ -22,7 +22,7 @@
     },
     {
       "name": "wil",
-      "version": "1.0.250325.1"
+      "version": "1.0.260126.7"
     }
   ]
 }


### PR DESCRIPTION
This updates GSL to version 4.2.2 to fix compilation with the latest VS 2026 toolset.

It also updates WIL to version 1.0.260126.7.